### PR TITLE
Atualiza layout do menu lateral e estilos de botoes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,27 @@
   </head>
   <body>
     <aside class="sidebar">
-      <button class="icon-button" aria-label="Calendário">
-        <span class="material-symbol">📅</span>
+      <button class="icon-button" aria-label="Calendário" data-tooltip="Calendário">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="17" rx="2"></rect>
+          <line x1="3" y1="9" x2="21" y2="9"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+        </svg>
       </button>
-      <button class="icon-button" aria-label="Clientes">
-        <span class="material-symbol">👥</span>
+      <button class="icon-button" aria-label="Clientes" data-tooltip="Clientes">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="8" cy="8" r="3"></circle>
+          <circle cx="16" cy="11" r="3"></circle>
+          <path d="M3 19c0-2.7614 2.2386-5 5-5h0.5"></path>
+          <path d="M12 19c0-2.7614 2.2386-5 5-5h1"></path>
+        </svg>
       </button>
-      <button class="icon-button" aria-label="Contatos">
-        <span class="material-symbol">💬</span>
+      <button class="icon-button" aria-label="Contatos" data-tooltip="Contatos">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="14" rx="2"></rect>
+          <polyline points="7,20 7,16 12,16 12,20"></polyline>
+        </svg>
       </button>
     </aside>
     <header class="topbar">
@@ -25,9 +38,6 @@
         <button class="topbar__button">Ação 3</button>
       </nav>
     </header>
-    <main class="content">
-      <h1>Bem-vindo ao CRM Equal</h1>
-      <p>Conteúdo principal aqui.</p>
-    </main>
+    <main class="content"></main>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -13,7 +13,7 @@ body {
   background-color: #1f1f1f;
   color: #ffffff;
   display: grid;
-  grid-template-columns: 80px 1fr;
+  grid-template-columns: 50px 1fr;
   grid-template-rows: 50px 1fr;
   grid-template-areas:
     "sidebar topbar"
@@ -28,12 +28,13 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  padding: 50px 20px;
-  width: 80px;
+  padding: 50px 5px;
+  width: 50px;
   font-size: 14px;
 }
 
 .icon-button {
+  position: relative;
   width: 40px;
   height: 40px;
   border-radius: 12px;
@@ -46,11 +47,48 @@ body {
   font-size: 20px;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 .icon-button:hover,
 .icon-button:focus {
   background-color: #2c2c2c;
+}
+
+.icon-button svg {
+  width: 20px;
+  height: 20px;
+  stroke: #ffffff;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-button::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: #2c2c2c;
+  color: #ffffff;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+}
+
+.icon-button:hover::after,
+.icon-button:focus-visible::after {
+  opacity: 1;
+  transform: translate(8px, -50%);
 }
 
 .topbar {
@@ -81,6 +119,8 @@ body {
   font-family: inherit;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 .topbar__button:hover,


### PR DESCRIPTION
## Resumo
- substitui emojis por ícones vetoriais monocromáticos no menu lateral e adiciona tooltips
- ajusta largura da barra lateral para 50px e remove textos do conteúdo principal
- aplica letras maiúsculas e negrito aos botões para consistência visual

## Testes
- nenhum teste automatizado foi executado

------
https://chatgpt.com/codex/tasks/task_e_68dd7d89aadc8333a45dc26a4252036e