### PR TITLE
Implement calendar layout for calendar page

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,8 +91,41 @@
       </header>
       <main class="content">
         <section class="content__page is-active" data-page="calendario">
-          <h1>Calendário</h1>
-          <p>Selecione uma ação no menu superior para gerenciar seus eventos e folgas.</p>
+          <div class="calendar" aria-label="Calendário mensal">
+            <div class="calendar__menu" role="toolbar">
+              <button class="calendar__month-button" type="button">
+                <span class="calendar__month-label" aria-live="polite"></span>
+              </button>
+              <div class="calendar__nav">
+                <button
+                  class="calendar__nav-button calendar__nav-button--prev"
+                  type="button"
+                  aria-label="Mês anterior"
+                >
+                  <span aria-hidden="true">&#8249;</span>
+                </button>
+                <button
+                  class="calendar__nav-button calendar__nav-button--next"
+                  type="button"
+                  aria-label="Próximo mês"
+                >
+                  <span aria-hidden="true">&#8250;</span>
+                </button>
+              </div>
+            </div>
+            <div class="calendar__grid" role="grid">
+              <div class="calendar__weekdays" role="row">
+                <span class="calendar__weekday" role="columnheader">DOM</span>
+                <span class="calendar__weekday" role="columnheader">SEG</span>
+                <span class="calendar__weekday" role="columnheader">TER</span>
+                <span class="calendar__weekday" role="columnheader">QUA</span>
+                <span class="calendar__weekday" role="columnheader">QUI</span>
+                <span class="calendar__weekday" role="columnheader">SEX</span>
+                <span class="calendar__weekday" role="columnheader">SÁB</span>
+              </div>
+              <div class="calendar__dates" role="rowgroup"></div>
+            </div>
+          </div>
         </section>
         <section class="content__page" data-page="clientes">
           <h1>Clientes</h1>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,79 @@ const sidebarButtons = document.querySelectorAll('.icon-button');
 const titleElement = document.querySelector('.topbar__title');
 const menus = document.querySelectorAll('.topbar__menu');
 const contentPages = document.querySelectorAll('.content__page');
+const monthLabel = document.querySelector('.calendar__month-label');
+const prevMonthButton = document.querySelector('.calendar__nav-button--prev');
+const nextMonthButton = document.querySelector('.calendar__nav-button--next');
+const datesContainer = document.querySelector('.calendar__dates');
+
+const MONTH_NAMES = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro',
+];
+
+let currentCalendarDate = new Date();
+
+function createDateCell(content, isEmpty = false) {
+  const cell = document.createElement('div');
+  cell.className = 'calendar__date';
+  if (isEmpty) {
+    cell.classList.add('calendar__date--empty');
+    return cell;
+  }
+
+  const span = document.createElement('span');
+  span.textContent = content;
+  cell.appendChild(span);
+  return cell;
+}
+
+function renderCalendar() {
+  if (!monthLabel || !datesContainer) {
+    return;
+  }
+
+  const year = currentCalendarDate.getFullYear();
+  const month = currentCalendarDate.getMonth();
+  const firstDayOfMonth = new Date(year, month, 1);
+  const firstWeekday = firstDayOfMonth.getDay();
+  const totalDays = new Date(year, month + 1, 0).getDate();
+
+  monthLabel.textContent = `${MONTH_NAMES[month]} ${year}`;
+
+  datesContainer.innerHTML = '';
+
+  for (let i = 0; i < firstWeekday; i += 1) {
+    datesContainer.appendChild(createDateCell('', true));
+  }
+
+  for (let day = 1; day <= totalDays; day += 1) {
+    datesContainer.appendChild(createDateCell(day));
+  }
+
+  const totalCells = datesContainer.children.length;
+  const remainder = totalCells % 7;
+  if (remainder !== 0) {
+    const emptyCellsToAdd = 7 - remainder;
+    for (let i = 0; i < emptyCellsToAdd; i += 1) {
+      datesContainer.appendChild(createDateCell('', true));
+    }
+  }
+}
+
+function changeMonth(offset) {
+  currentCalendarDate.setMonth(currentCalendarDate.getMonth() + offset, 1);
+  renderCalendar();
+}
 
 function setActivePage(page) {
   sidebarButtons.forEach((button) => {
@@ -35,3 +108,10 @@ sidebarButtons.forEach((button) => {
 });
 
 setActivePage('calendario');
+
+if (prevMonthButton && nextMonthButton) {
+  prevMonthButton.addEventListener('click', () => changeMonth(-1));
+  nextMonthButton.addEventListener('click', () => changeMonth(1));
+}
+
+renderCalendar();

--- a/styles.css
+++ b/styles.css
@@ -247,6 +247,106 @@ body {
   display: flex;
 }
 
+.calendar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 5px;
+}
+
+.calendar__menu {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.calendar__month-button {
+  height: 40px;
+  padding: 0 20px;
+  border-radius: 12px;
+  border: none;
+  background-color: #2c2c2c;
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+}
+
+.calendar__nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.calendar__nav-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: none;
+  background-color: #2c2c2c;
+  color: #ffffff;
+  font-size: 24px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.calendar__nav-button:hover,
+.calendar__nav-button:focus {
+  background-color: #3a3a3a;
+}
+
+.calendar__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.calendar__weekdays,
+.calendar__dates {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+}
+
+.calendar__weekday {
+  font-size: 15px;
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+}
+
+.calendar__dates {
+  grid-auto-rows: 70px;
+}
+
+.calendar__date {
+  background-color: #2a2a2a;
+  border-radius: 12px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 8px;
+  color: #b5b5b5;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.calendar__date span {
+  line-height: 1;
+}
+
+.calendar__date--empty {
+  background-color: transparent;
+}
+
 .content h1 {
   font-size: 32px;
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- implement calendar markup with navigation controls on the calendário page
- style the calendar interface to match the dark theme layout requirements
- add JavaScript to render the current month and handle month navigation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd88ffa72883339af9bd165f929417