### PR TITLE
Atualiza layout do calendário

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,10 +93,17 @@
         <section class="content__page is-active" data-page="calendario">
           <div class="calendar" aria-label="Calendário mensal">
             <div class="calendar__menu" role="toolbar">
-              <button class="calendar__month-button" type="button">
-                <span class="calendar__month-label" aria-live="polite"></span>
-              </button>
+              <div class="calendar__menu-spacer" aria-hidden="true"></div>
+              <div class="calendar__month-display" aria-live="polite">
+                <span class="calendar__month-label"></span>
+              </div>
               <div class="calendar__nav">
+                <button
+                  class="calendar__nav-button calendar__nav-button--today"
+                  type="button"
+                >
+                  HOJE
+                </button>
                 <button
                   class="calendar__nav-button calendar__nav-button--prev"
                   type="button"

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const contentPages = document.querySelectorAll('.content__page');
 const monthLabel = document.querySelector('.calendar__month-label');
 const prevMonthButton = document.querySelector('.calendar__nav-button--prev');
 const nextMonthButton = document.querySelector('.calendar__nav-button--next');
+const todayButton = document.querySelector('.calendar__nav-button--today');
 const datesContainer = document.querySelector('.calendar__dates');
 
 const MONTH_NAMES = [
@@ -24,7 +25,7 @@ const MONTH_NAMES = [
 
 let currentCalendarDate = new Date();
 
-function createDateCell(content, isEmpty = false) {
+function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
   const cell = document.createElement('div');
   cell.className = 'calendar__date';
   if (isEmpty) {
@@ -33,6 +34,10 @@ function createDateCell(content, isEmpty = false) {
   }
 
   const span = document.createElement('span');
+  if (isToday) {
+    cell.classList.add('calendar__date--today');
+  }
+  span.className = 'calendar__date-number';
   span.textContent = content;
   cell.appendChild(span);
   return cell;
@@ -54,11 +59,18 @@ function renderCalendar() {
   datesContainer.innerHTML = '';
 
   for (let i = 0; i < firstWeekday; i += 1) {
-    datesContainer.appendChild(createDateCell('', true));
+    datesContainer.appendChild(createDateCell('', { isEmpty: true }));
   }
 
+  const today = new Date();
+
   for (let day = 1; day <= totalDays; day += 1) {
-    datesContainer.appendChild(createDateCell(day));
+    const isToday =
+      day === today.getDate() &&
+      month === today.getMonth() &&
+      year === today.getFullYear();
+
+    datesContainer.appendChild(createDateCell(day, { isToday }));
   }
 
   const totalCells = datesContainer.children.length;
@@ -66,7 +78,7 @@ function renderCalendar() {
   if (remainder !== 0) {
     const emptyCellsToAdd = 7 - remainder;
     for (let i = 0; i < emptyCellsToAdd; i += 1) {
-      datesContainer.appendChild(createDateCell('', true));
+      datesContainer.appendChild(createDateCell('', { isEmpty: true }));
     }
   }
 }
@@ -112,6 +124,14 @@ setActivePage('calendario');
 if (prevMonthButton && nextMonthButton) {
   prevMonthButton.addEventListener('click', () => changeMonth(-1));
   nextMonthButton.addEventListener('click', () => changeMonth(1));
+}
+
+if (todayButton) {
+  todayButton.addEventListener('click', () => {
+    currentCalendarDate = new Date();
+    currentCalendarDate.setDate(1);
+    renderCalendar();
+  });
 }
 
 renderCalendar();

--- a/styles.css
+++ b/styles.css
@@ -95,7 +95,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: 15px 15px 32px;
-  gap: 24px;
+  gap: 15px;
 }
 
 .topbar {
@@ -234,7 +234,7 @@ body {
   flex: 1;
   background-color: #141414;
   border-radius: 18px;
-  padding: 32px;
+  padding: 15px 32px 32px;
 }
 
 .content__page {
@@ -251,35 +251,38 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin-top: 5px;
 }
 
 .calendar__menu {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
+  width: 100%;
 }
 
-.calendar__month-button {
-  height: 40px;
-  padding: 0 20px;
-  border-radius: 12px;
-  border: none;
-  background-color: #2c2c2c;
-  color: #ffffff;
+.calendar__menu-spacer {
+  justify-self: start;
+}
+
+.calendar__month-display {
+  justify-self: center;
+  text-align: center;
   font-size: 20px;
   font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: default;
+  color: #ffffff;
+  letter-spacing: 0.04em;
+}
+
+.calendar__month-label {
+  text-transform: uppercase;
 }
 
 .calendar__nav {
   display: flex;
   align-items: center;
   gap: 8px;
+  justify-self: end;
 }
 
 .calendar__nav-button {
@@ -303,6 +306,14 @@ body {
   background-color: #3a3a3a;
 }
 
+.calendar__nav-button--today {
+  width: auto;
+  padding: 0 18px;
+  font-size: 15px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .calendar__grid {
   display: flex;
   flex-direction: column;
@@ -321,6 +332,8 @@ body {
   font-weight: 700;
   color: #ffffff;
   text-align: center;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .calendar__dates {
@@ -339,8 +352,23 @@ body {
   font-size: 16px;
 }
 
-.calendar__date span {
+.calendar__date-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
   line-height: 1;
+}
+
+.calendar__date--today {
+  color: #ffffff;
+}
+
+.calendar__date--today .calendar__date-number {
+  background-color: #2e7d32;
+  box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.35);
 }
 
 .calendar__date--empty {


### PR DESCRIPTION
## Summary
- centralizei o cabeçalho do calendário e inclui o novo botão HOJE para voltar ao mês atual
- removi o fundo do título do mês e estilizei os dias da semana com linhas divisórias sutis
- destaquei a data atual com um balão verde e reduzi os espaçamentos superiores conforme solicitado

## Testing
- Não foram executados testes automatizados (não se aplica)


------
https://chatgpt.com/codex/tasks/task_e_68dd8f8e2f44833392c171f86210f71f