### PR TITLE
Atualiza interface do calendário com novo layout de datas

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,11 +54,6 @@
         <div class="topbar__title" aria-live="polite">CALENDÁRIO</div>
         <div class="topbar__menus">
           <div class="topbar__menu is-active" data-page="calendario">
-            <div class="topbar__group topbar__group--left">
-              <button class="topbar__button topbar__button--orange">
-                Adicionar Evento
-              </button>
-            </div>
             <div class="topbar__group topbar__group--right">
               <button class="topbar__button">Folgas</button>
               <button class="topbar__button topbar__button--orange">Eventos</button>
@@ -93,7 +88,13 @@
         <section class="content__page is-active" data-page="calendario">
           <div class="calendar" aria-label="Calendário mensal">
             <div class="calendar__menu" role="toolbar">
-              <div class="calendar__menu-spacer" aria-hidden="true"></div>
+              <button
+                class="calendar__add-button"
+                type="button"
+                aria-label="Adicionar evento"
+              >
+                +
+              </button>
               <div class="calendar__month-display" aria-live="polite">
                 <span class="calendar__month-label"></span>
               </div>

--- a/script.js
+++ b/script.js
@@ -33,13 +33,30 @@ function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
     return cell;
   }
 
-  const span = document.createElement('span');
   if (isToday) {
     cell.classList.add('calendar__date--today');
   }
+
+  const header = document.createElement('div');
+  header.className = 'calendar__date-header';
+
+  const span = document.createElement('span');
   span.className = 'calendar__date-number';
   span.textContent = content;
-  cell.appendChild(span);
+  header.appendChild(span);
+
+  if (isToday) {
+    const todayTag = document.createElement('span');
+    todayTag.className = 'calendar__date-today-tag';
+    todayTag.textContent = '(hoje)';
+    header.appendChild(todayTag);
+  }
+
+  cell.appendChild(header);
+
+  const eventsContainer = document.createElement('div');
+  eventsContainer.className = 'calendar__date-events';
+  cell.appendChild(eventsContainer);
   return cell;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -255,23 +255,41 @@ body {
 
 .calendar__menu {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 16px;
   width: 100%;
 }
 
-.calendar__menu-spacer {
-  justify-self: start;
-}
-
 .calendar__month-display {
   justify-self: center;
   text-align: center;
-  font-size: 20px;
+  font-size: 25px;
   font-weight: 700;
   color: #ffffff;
   letter-spacing: 0.04em;
+}
+
+.calendar__add-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: none;
+  background-color: #ff9800;
+  color: #141414;
+  font-size: 26px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.calendar__add-button:hover,
+.calendar__add-button:focus {
+  background-color: #ffb74d;
+  transform: scale(1.05);
 }
 
 .calendar__month-label {
@@ -337,29 +355,60 @@ body {
 }
 
 .calendar__dates {
-  grid-auto-rows: 70px;
+  grid-auto-rows: minmax(80px, auto);
 }
 
 .calendar__date {
   background-color: #2a2a2a;
   border-radius: 12px;
   display: flex;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 8px;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
   color: #b5b5b5;
   font-weight: 600;
   font-size: 16px;
+}
+
+.calendar__date-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
 }
 
 .calendar__date-number {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   border-radius: 999px;
   line-height: 1;
+}
+
+.calendar__date-today-tag {
+  font-size: 12px;
+  color: #81c784;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.calendar__date-events {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.calendar__event-chip {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #ffffff;
+  width: fit-content;
 }
 
 .calendar__date--today {
@@ -368,11 +417,12 @@ body {
 
 .calendar__date--today .calendar__date-number {
   background-color: #2e7d32;
-  box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.35);
+  box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.3);
 }
 
 .calendar__date--empty {
   background-color: transparent;
+  padding: 0;
 }
 
 .content h1 {


### PR DESCRIPTION
## Resumo
- reorganiza o menu do calendário com botão de atalho laranja e remove o botão superior de adicionar evento
- aumenta a tipografia do mês/ano e ajusta a célula diária para altura base de 80px com nova divisão entre título e eventos
- reduz o destaque do dia atual e prepara espaço para exibição de chips de eventos

## Testes
- Nenhum (não aplicável)

------
https://chatgpt.com/codex/tasks/task_e_68dd9354e2f8833399ad57c9d67400a5