### PR TITLE
Add interactive calendar event management

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,98 @@
         </section>
       </main>
     </div>
+    <div class="modal-overlay" data-modal="add-event" aria-hidden="true">
+      <div
+        class="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-event-title"
+      >
+        <div class="modal__header">
+          <h2 class="modal__title" id="add-event-title">Adicionar evento</h2>
+          <button
+            class="modal__close"
+            type="button"
+            data-action="close"
+            aria-label="Fechar modal"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="modal__content">
+          <form class="modal__form" autocomplete="off">
+            <label class="modal__field">
+              <span class="modal__label">Data do evento</span>
+              <input class="modal__input" type="date" name="date" required />
+            </label>
+            <label class="modal__field">
+              <span class="modal__label">Título</span>
+              <input
+                class="modal__input"
+                type="text"
+                name="title"
+                placeholder="Título do evento"
+                required
+              />
+            </label>
+            <label class="modal__field">
+              <span class="modal__label">Descrição</span>
+              <textarea
+                class="modal__textarea"
+                name="description"
+                placeholder="Detalhes do evento"
+              ></textarea>
+            </label>
+          </form>
+        </div>
+        <div class="modal__footer">
+          <button class="modal__save-button" type="button" data-action="save">
+            Salvar
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="modal-overlay" data-modal="event-details" aria-hidden="true">
+      <div
+        class="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-details-title"
+      >
+        <div class="modal__header">
+          <h2 class="modal__title" id="event-details-title">Detalhes do evento</h2>
+          <button
+            class="modal__close"
+            type="button"
+            data-action="close"
+            aria-label="Fechar modal"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="modal__content">
+          <div class="modal__details-content" data-details="body"></div>
+        </div>
+        <div class="modal__actions">
+          <button
+            class="modal__action modal__action--edit"
+            type="button"
+            data-action="edit"
+            aria-label="Editar evento"
+          >
+            ✎
+          </button>
+          <button
+            class="modal__action modal__action--delete"
+            type="button"
+            data-action="delete"
+            aria-label="Excluir evento"
+          >
+            🗑
+          </button>
+        </div>
+      </div>
+    </div>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,25 @@ const prevMonthButton = document.querySelector('.calendar__nav-button--prev');
 const nextMonthButton = document.querySelector('.calendar__nav-button--next');
 const todayButton = document.querySelector('.calendar__nav-button--today');
 const datesContainer = document.querySelector('.calendar__dates');
+const addEventButton = document.querySelector('.calendar__add-button');
+const addEventOverlay = document.querySelector('[data-modal="add-event"]');
+const addEventForm = addEventOverlay?.querySelector('.modal__form');
+const addEventCloseButton = addEventOverlay?.querySelector('[data-action="close"]');
+const addEventSaveButton = addEventOverlay?.querySelector('[data-action="save"]');
+const eventDetailsOverlay = document.querySelector('[data-modal="event-details"]');
+const eventDetailsBody = eventDetailsOverlay?.querySelector('[data-details="body"]');
+const eventDetailsCloseButton = eventDetailsOverlay?.querySelector('[data-action="close"]');
+const eventDetailsEditButton = eventDetailsOverlay?.querySelector('[data-action="edit"]');
+const eventDetailsDeleteButton = eventDetailsOverlay?.querySelector('[data-action="delete"]');
+const eventDetailsModal = eventDetailsOverlay?.querySelector('.modal');
+
+const events = {};
+let eventIdCounter = 0;
+let editingEvent = null;
+let editingEventOriginalDateKey = null;
+let currentDetailEvent = null;
+let detailAutoCloseTimeout = null;
+let isDetailHovered = false;
 
 const MONTH_NAMES = [
   'Janeiro',
@@ -25,7 +44,26 @@ const MONTH_NAMES = [
 
 let currentCalendarDate = new Date();
 
-function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
+function formatDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatDisplayDate(dateKey) {
+  const [year, month, day] = dateKey.split('-');
+  return `${day}/${month}/${year}`;
+}
+
+function ensureEventsArray(dateKey) {
+  if (!events[dateKey]) {
+    events[dateKey] = [];
+  }
+  return events[dateKey];
+}
+
+function createDateCell(content, { isEmpty = false, isToday = false, dateKey = '' } = {}) {
   const cell = document.createElement('div');
   cell.className = 'calendar__date';
   if (isEmpty) {
@@ -35,6 +73,10 @@ function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
 
   if (isToday) {
     cell.classList.add('calendar__date--today');
+  }
+
+  if (dateKey) {
+    cell.dataset.dateKey = dateKey;
   }
 
   const header = document.createElement('div');
@@ -48,7 +90,8 @@ function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
   if (isToday) {
     const todayTag = document.createElement('span');
     todayTag.className = 'calendar__date-today-tag';
-    todayTag.textContent = '(hoje)';
+    todayTag.textContent = 'HOJE';
+    todayTag.setAttribute('aria-label', 'Data de hoje');
     header.appendChild(todayTag);
   }
 
@@ -58,6 +101,26 @@ function createDateCell(content, { isEmpty = false, isToday = false } = {}) {
   eventsContainer.className = 'calendar__date-events';
   cell.appendChild(eventsContainer);
   return cell;
+}
+
+function renderEventsForCell(cell, dateKey) {
+  const eventsContainer = cell.querySelector('.calendar__date-events');
+  if (!eventsContainer) {
+    return;
+  }
+
+  eventsContainer.innerHTML = '';
+  const dateEvents = events[dateKey] || [];
+
+  dateEvents.forEach((event) => {
+    const chip = document.createElement('button');
+    chip.className = 'calendar__event-chip';
+    chip.type = 'button';
+    chip.textContent = event.title;
+    chip.dataset.eventId = String(event.id);
+    chip.addEventListener('click', () => openEventDetailsModal(event));
+    eventsContainer.appendChild(chip);
+  });
 }
 
 function renderCalendar() {
@@ -87,7 +150,11 @@ function renderCalendar() {
       month === today.getMonth() &&
       year === today.getFullYear();
 
-    datesContainer.appendChild(createDateCell(day, { isToday }));
+    const cellDate = new Date(year, month, day);
+    const dateKey = formatDateKey(cellDate);
+    const cell = createDateCell(day, { isToday, dateKey });
+    renderEventsForCell(cell, dateKey);
+    datesContainer.appendChild(cell);
   }
 
   const totalCells = datesContainer.children.length;
@@ -103,6 +170,198 @@ function renderCalendar() {
 function changeMonth(offset) {
   currentCalendarDate.setMonth(currentCalendarDate.getMonth() + offset, 1);
   renderCalendar();
+}
+
+function toggleBodyModalState() {
+  const anyModalVisible = document.querySelector('.modal-overlay.is-visible');
+  if (anyModalVisible) {
+    document.body.classList.add('modal-open');
+  } else {
+    document.body.classList.remove('modal-open');
+  }
+}
+
+function openOverlay(overlay) {
+  if (!overlay) {
+    return;
+  }
+  overlay.classList.add('is-visible');
+  overlay.setAttribute('aria-hidden', 'false');
+  toggleBodyModalState();
+}
+
+function closeOverlay(overlay) {
+  if (!overlay) {
+    return;
+  }
+  overlay.classList.remove('is-visible');
+  overlay.setAttribute('aria-hidden', 'true');
+  toggleBodyModalState();
+}
+
+function resetAddEventForm() {
+  if (!addEventForm) {
+    return;
+  }
+  addEventForm.reset();
+}
+
+function openAddEventModal(eventData = null) {
+  if (!addEventForm || !addEventOverlay) {
+    return;
+  }
+
+  editingEvent = eventData;
+  editingEventOriginalDateKey = eventData ? eventData.date : null;
+
+  const todayKey = formatDateKey(new Date());
+  const dateInput = addEventForm.elements.namedItem('date');
+  const titleInput = addEventForm.elements.namedItem('title');
+  const descriptionInput = addEventForm.elements.namedItem('description');
+
+  if (dateInput) {
+    dateInput.value = eventData ? eventData.date : todayKey;
+  }
+  if (titleInput) {
+    titleInput.value = eventData ? eventData.title : '';
+  }
+  if (descriptionInput) {
+    descriptionInput.value = eventData ? eventData.description : '';
+  }
+
+  openOverlay(addEventOverlay);
+}
+
+function closeAddEventModal() {
+  closeOverlay(addEventOverlay);
+  resetAddEventForm();
+  editingEvent = null;
+  editingEventOriginalDateKey = null;
+}
+
+function removeEventFromDate(eventId, dateKey) {
+  const dateEvents = events[dateKey];
+  if (!dateEvents) {
+    return;
+  }
+  const index = dateEvents.findIndex((item) => item.id === eventId);
+  if (index !== -1) {
+    dateEvents.splice(index, 1);
+    if (dateEvents.length === 0) {
+      delete events[dateKey];
+    }
+  }
+}
+
+function handleSaveEvent() {
+  if (!addEventForm) {
+    return;
+  }
+
+  if (!addEventForm.reportValidity()) {
+    return;
+  }
+
+  const formData = new FormData(addEventForm);
+  const dateValue = formData.get('date');
+  const titleValue = String(formData.get('title') || '').trim();
+  const descriptionValue = String(formData.get('description') || '').trim();
+
+  if (!dateValue || !titleValue) {
+    return;
+  }
+
+  if (editingEvent) {
+    if (editingEventOriginalDateKey && editingEventOriginalDateKey !== dateValue) {
+      removeEventFromDate(editingEvent.id, editingEventOriginalDateKey);
+      editingEvent.date = dateValue;
+      ensureEventsArray(dateValue).push(editingEvent);
+    } else {
+      editingEvent.date = dateValue;
+    }
+
+    editingEvent.title = titleValue;
+    editingEvent.description = descriptionValue;
+  } else {
+    eventIdCounter += 1;
+    const newEvent = {
+      id: eventIdCounter,
+      date: dateValue,
+      title: titleValue,
+      description: descriptionValue,
+    };
+    ensureEventsArray(dateValue).push(newEvent);
+  }
+
+  closeAddEventModal();
+  renderCalendar();
+}
+
+function clearDetailAutoClose() {
+  if (detailAutoCloseTimeout) {
+    clearTimeout(detailAutoCloseTimeout);
+    detailAutoCloseTimeout = null;
+  }
+}
+
+function scheduleDetailAutoClose(delay) {
+  clearDetailAutoClose();
+  detailAutoCloseTimeout = setTimeout(() => {
+    if (!isDetailHovered) {
+      closeEventDetailsModal();
+    }
+  }, delay);
+}
+
+function closeEventDetailsModal() {
+  closeOverlay(eventDetailsOverlay);
+  clearDetailAutoClose();
+  currentDetailEvent = null;
+}
+
+function createDetailsRow(label, value, isEmpty = false) {
+  const container = document.createElement('div');
+  container.className = 'modal__details-row';
+
+  const labelElement = document.createElement('span');
+  labelElement.textContent = label;
+  container.appendChild(labelElement);
+
+  if (isEmpty) {
+    const emptyMessage = document.createElement('p');
+    emptyMessage.className = 'modal__empty-message';
+    emptyMessage.textContent = value;
+    container.appendChild(emptyMessage);
+    return container;
+  }
+
+  const valueElement = document.createElement('p');
+  valueElement.textContent = value;
+  container.appendChild(valueElement);
+  return container;
+}
+
+function openEventDetailsModal(event) {
+  if (!eventDetailsOverlay || !eventDetailsBody) {
+    return;
+  }
+
+  currentDetailEvent = event;
+  eventDetailsBody.innerHTML = '';
+  eventDetailsBody.appendChild(createDetailsRow('Data', formatDisplayDate(event.date)));
+  eventDetailsBody.appendChild(createDetailsRow('Título', event.title));
+
+  if (event.description) {
+    eventDetailsBody.appendChild(createDetailsRow('Descrição', event.description));
+  } else {
+    eventDetailsBody.appendChild(
+      createDetailsRow('Descrição', 'Nenhuma descrição informada.', true)
+    );
+  }
+
+  openOverlay(eventDetailsOverlay);
+  isDetailHovered = false;
+  scheduleDetailAutoClose(5000);
 }
 
 function setActivePage(page) {
@@ -150,5 +409,81 @@ if (todayButton) {
     renderCalendar();
   });
 }
+
+if (addEventButton) {
+  addEventButton.addEventListener('click', () => openAddEventModal());
+}
+
+if (addEventOverlay) {
+  addEventOverlay.addEventListener('click', (event) => {
+    if (event.target === addEventOverlay) {
+      closeAddEventModal();
+    }
+  });
+}
+
+addEventCloseButton?.addEventListener('click', () => {
+  closeAddEventModal();
+});
+
+addEventSaveButton?.addEventListener('click', () => {
+  handleSaveEvent();
+});
+
+addEventForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  handleSaveEvent();
+});
+
+if (eventDetailsOverlay) {
+  eventDetailsOverlay.addEventListener('click', (event) => {
+    if (event.target === eventDetailsOverlay) {
+      closeEventDetailsModal();
+    }
+  });
+}
+
+eventDetailsCloseButton?.addEventListener('click', () => {
+  closeEventDetailsModal();
+});
+
+eventDetailsEditButton?.addEventListener('click', () => {
+  if (!currentDetailEvent) {
+    return;
+  }
+  const eventToEdit = currentDetailEvent;
+  closeEventDetailsModal();
+  openAddEventModal(eventToEdit);
+});
+
+eventDetailsDeleteButton?.addEventListener('click', () => {
+  if (!currentDetailEvent) {
+    return;
+  }
+  removeEventFromDate(currentDetailEvent.id, currentDetailEvent.date);
+  closeEventDetailsModal();
+  renderCalendar();
+});
+
+eventDetailsModal?.addEventListener('mouseenter', () => {
+  isDetailHovered = true;
+  clearDetailAutoClose();
+});
+
+eventDetailsModal?.addEventListener('mouseleave', () => {
+  isDetailHovered = false;
+  scheduleDetailAutoClose(3000);
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') {
+    return;
+  }
+  if (eventDetailsOverlay?.classList.contains('is-visible')) {
+    closeEventDetailsModal();
+  } else if (addEventOverlay?.classList.contains('is-visible')) {
+    closeAddEventModal();
+  }
+});
 
 renderCalendar();

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,10 @@ body {
   min-height: 100vh;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 .sidebar {
   background-color: #141414;
   display: flex;
@@ -271,13 +275,13 @@ body {
 }
 
 .calendar__add-button {
-  width: 40px;
-  height: 40px;
+  width: 35px;
+  height: 35px;
   border-radius: 12px;
   border: none;
   background-color: #ff9800;
   color: #141414;
-  font-size: 26px;
+  font-size: 22px;
   font-weight: 700;
   display: inline-flex;
   align-items: center;
@@ -304,13 +308,13 @@ body {
 }
 
 .calendar__nav-button {
-  width: 40px;
-  height: 40px;
+  width: 35px;
+  height: 35px;
   border-radius: 12px;
   border: none;
   background-color: #2c2c2c;
   color: #ffffff;
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 700;
   display: inline-flex;
   align-items: center;
@@ -330,6 +334,7 @@ body {
   font-size: 15px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  height: 35px;
 }
 
 .calendar__grid {
@@ -389,7 +394,7 @@ body {
 
 .calendar__date-today-tag {
   font-size: 12px;
-  color: #81c784;
+  color: #00e676;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -402,13 +407,26 @@ body {
 }
 
 .calendar__event-chip {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: #ff9800;
   border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 13px;
+  padding: 4px 10px;
+  font-size: 12px;
   font-weight: 600;
-  color: #ffffff;
+  color: #141414;
   width: fit-content;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.calendar__event-chip:hover,
+.calendar__event-chip:focus {
+  transform: translateY(-2px);
+}
+
+.calendar__event-chip:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
 }
 
 .calendar__date--today {
@@ -418,6 +436,178 @@ body {
 .calendar__date--today .calendar__date-number {
   background-color: #2e7d32;
   box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.3);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.65);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.modal-overlay.is-visible {
+  display: flex;
+}
+
+.modal {
+  background-color: #1f1f1f;
+  border-radius: 16px;
+  width: min(480px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  position: relative;
+  padding: 24px;
+  gap: 16px;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal__title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal__label {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modal__input,
+.modal__textarea {
+  background-color: #2c2c2c;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 15px;
+  font-family: inherit;
+  color: #ffffff;
+}
+
+.modal__input:focus,
+.modal__textarea:focus {
+  outline: none;
+  border-color: #ff9800;
+}
+
+.modal__textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.modal__footer {
+  margin-left: auto;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.modal__save-button {
+  background-color: #00e676;
+  color: #0c0c0c;
+  border: none;
+  padding: 10px 22px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modal__save-button:hover,
+.modal__save-button:focus {
+  background-color: #00c853;
+}
+
+.modal__details-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 15px;
+}
+
+.modal__details-content span {
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.75);
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+
+.modal__details-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modal__actions {
+  margin-left: auto;
+  margin-top: auto;
+  display: flex;
+  gap: 10px;
+}
+
+.modal__action {
+  background: transparent;
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal__action--edit {
+  color: #ff9800;
+}
+
+.modal__action--delete {
+  color: #ff5252;
+}
+
+.modal__empty-message {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 14px;
 }
 
 .calendar__date--empty {


### PR DESCRIPTION
## Summary
- update calendar menu controls and today highlight styling for improved consistency
- add add-event and event-details modals with darkened backdrop and contextual actions
- implement client-side event storage, rendering, and modal behaviors including timed auto-close

## Testing
- No automated tests were run (project does not include a test suite)


------
https://chatgpt.com/codex/tasks/task_e_68dd97e0960c8333954f847f5321b6d8