### PR TITLE
Add home dashboard with quick links and summary cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,19 @@
         <button
           class="icon-button is-active"
           type="button"
+          aria-label="Home"
+          data-tooltip="Home"
+          data-page="home"
+          data-label="Home"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3 11.5 12 4l9 7.5" />
+            <path d="M5 10.5V20h5v-4h4v4h5v-9.5" />
+          </svg>
+        </button>
+        <button
+          class="icon-button"
+          type="button"
           aria-label="Calendário"
           data-tooltip="Calendário"
           data-page="calendario"
@@ -77,9 +90,14 @@
 
     <div class="workspace">
       <header class="topbar">
-        <div class="topbar__title" aria-live="polite">CALENDÁRIO</div>
+        <div class="topbar__title" aria-live="polite">HOME</div>
         <div class="topbar__menus">
-          <div class="topbar__menu is-active" data-page="calendario">
+          <div class="topbar__menu is-active" data-page="home">
+            <div class="topbar__group topbar__group--left home-topbar__group">
+              <p class="home-topbar__text">Bem-vindo ao seu painel geral.</p>
+            </div>
+          </div>
+          <div class="topbar__menu" data-page="calendario">
             <div class="topbar__group topbar__group--right">
               <button class="topbar__button">Folgas</button>
               <button class="topbar__button topbar__button--orange">Eventos</button>
@@ -119,7 +137,136 @@
         </div>
       </header>
       <main class="content">
-        <section class="content__page is-active" data-page="calendario">
+        <section class="content__page home-page is-active" data-page="home">
+          <div class="home-page__shortcuts" aria-label="Acesso rápido às páginas">
+            <button
+              class="home-shortcut home-shortcut--calendar"
+              type="button"
+              data-page-target="calendario"
+            >
+              <span class="home-shortcut__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" aria-label="Calendário">
+                  <rect x="3" y="4" width="18" height="17" rx="2"></rect>
+                  <line x1="3" y1="9" x2="21" y2="9"></line>
+                  <line x1="8" y1="2" x2="8" y2="6"></line>
+                  <line x1="16" y1="2" x2="16" y2="6"></line>
+                </svg>
+              </span>
+              <span class="home-shortcut__label">Calendário</span>
+            </button>
+            <button
+              class="home-shortcut home-shortcut--clients"
+              type="button"
+              data-page-target="clientes"
+            >
+              <span class="home-shortcut__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" aria-label="Clientes">
+                  <circle cx="8" cy="8" r="3"></circle>
+                  <circle cx="16" cy="11" r="3"></circle>
+                  <path d="M3 19c0-2.7614 2.2386-5 5-5h0.5"></path>
+                  <path d="M12 19c0-2.7614 2.2386-5 5-5h1"></path>
+                </svg>
+              </span>
+              <span class="home-shortcut__label">Clientes</span>
+            </button>
+            <button
+              class="home-shortcut home-shortcut--contacts"
+              type="button"
+              data-page-target="contatos"
+            >
+              <span class="home-shortcut__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" aria-label="Contatos">
+                  <rect x="3" y="4" width="18" height="14" rx="2"></rect>
+                  <polyline points="7,20 7,16 12,16 12,20"></polyline>
+                </svg>
+              </span>
+              <span class="home-shortcut__label">Contatos</span>
+            </button>
+          </div>
+
+          <div class="home-page__sections">
+            <article class="home-summary home-summary--calendar">
+              <header class="home-summary__header">
+                <span class="home-summary__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="img" aria-label="Calendário">
+                    <rect x="3" y="4" width="18" height="17" rx="2"></rect>
+                    <line x1="3" y1="9" x2="21" y2="9"></line>
+                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                  </svg>
+                </span>
+                <h2 class="home-summary__title">Calendário</h2>
+              </header>
+              <ul class="home-summary__metrics">
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Eventos pendentes</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+              </ul>
+              <button class="home-summary__action home-summary__action--calendar" type="button">
+                Adicionar evento
+              </button>
+            </article>
+
+            <article class="home-summary home-summary--clients">
+              <header class="home-summary__header">
+                <span class="home-summary__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="img" aria-label="Clientes">
+                    <circle cx="8" cy="8" r="3"></circle>
+                    <circle cx="16" cy="11" r="3"></circle>
+                    <path d="M3 19c0-2.7614 2.2386-5 5-5h0.5"></path>
+                    <path d="M12 19c0-2.7614 2.2386-5 5-5h1"></path>
+                  </svg>
+                </span>
+                <h2 class="home-summary__title">Clientes</h2>
+              </header>
+              <ul class="home-summary__metrics">
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Clientes cadastrados</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Clientes essa semana</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+              </ul>
+              <button class="home-summary__action home-summary__action--clients" type="button">
+                Adicionar cliente
+              </button>
+            </article>
+
+            <article class="home-summary home-summary--contacts">
+              <header class="home-summary__header">
+                <span class="home-summary__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="img" aria-label="Contatos">
+                    <rect x="3" y="4" width="18" height="14" rx="2"></rect>
+                    <polyline points="7,20 7,16 12,16 12,20"></polyline>
+                  </svg>
+                </span>
+                <h2 class="home-summary__title">Contatos</h2>
+              </header>
+              <ul class="home-summary__metrics">
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Para essa semana</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Para esse mês</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+                <li class="home-summary__metric">
+                  <span class="home-summary__label">Concluídos esse mês</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+                <li class="home-summary__metric home-summary__metric--delayed">
+                  <span class="home-summary__label">Contatos atrasados</span>
+                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="content__page" data-page="calendario">
           <div class="calendar" aria-label="Calendário mensal">
             <div class="calendar__menu" role="toolbar">
               <button

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -2,6 +2,7 @@ const sidebarButtons = document.querySelectorAll('.icon-button[data-page]');
 const titleElement = document.querySelector('.topbar__title');
 const menus = document.querySelectorAll('.topbar__menu');
 const contentPages = document.querySelectorAll('.content__page');
+const homeShortcuts = document.querySelectorAll('[data-page-target]');
 const monthLabel = document.querySelector('.calendar__month-label');
 const prevMonthButton = document.querySelector('.calendar__nav-button--prev');
 const nextMonthButton = document.querySelector('.calendar__nav-button--next');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -4,9 +4,19 @@ sidebarButtons.forEach((button) => {
   });
 });
 
+homeShortcuts.forEach((shortcut) => {
+  shortcut.addEventListener('click', () => {
+    const targetPage = shortcut.dataset.pageTarget;
+    if (!targetPage) {
+      return;
+    }
+    setActivePage(targetPage);
+  });
+});
+
 initializeUserSelector();
 
-setActivePage('calendario');
+setActivePage('home');
 
 if (prevMonthButton && nextMonthButton) {
   prevMonthButton.addEventListener('click', () => changeMonth(-1));

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,224 @@ body.modal-open {
   margin-left: auto;
 }
 
+.home-topbar__group {
+  justify-content: flex-start;
+}
+
+.home-topbar__text {
+  font-size: 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.content__page.home-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.home-page__shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  width: 100%;
+}
+
+.home-shortcut {
+  background-color: #141414;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  height: 100px;
+  min-width: 220px;
+  padding: 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: capitalize;
+  transition: transform 0.2s ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.home-shortcut:hover,
+.home-shortcut:focus-visible {
+  transform: translateY(-4px);
+}
+
+.home-shortcut:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 4px;
+}
+
+.home-shortcut__icon {
+  display: inline-flex;
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.home-shortcut__icon svg {
+  width: 32px;
+  height: 32px;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.home-shortcut--calendar {
+  color: #ff9800;
+}
+
+.home-shortcut--clients {
+  color: #4caf50;
+}
+
+.home-shortcut--contacts {
+  color: #42a5f5;
+}
+
+.home-page__sections {
+  display: grid;
+  gap: 24px;
+  width: 100%;
+  justify-items: center;
+}
+
+.home-summary {
+  background-color: #141414;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 24px 32px;
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  font-size: 20px;
+}
+
+.home-summary__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.home-summary__icon {
+  display: inline-flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.home-summary__icon svg {
+  width: 28px;
+  height: 28px;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.home-summary__title {
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.home-summary__metrics {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.home-summary__metric {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 50px;
+}
+
+.home-summary__label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.home-summary__value {
+  display: inline-flex;
+}
+
+.home-summary__value-bubble {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background-color: #2c2c2c;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.home-summary__action {
+  align-self: flex-start;
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  background-color: transparent;
+  font-size: 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.home-summary__action:hover,
+.home-summary__action:focus-visible {
+  background-color: currentColor;
+  color: #141414;
+}
+
+.home-summary--calendar .home-summary__label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.home-summary--calendar .home-summary__icon {
+  color: #ff9800;
+}
+
+.home-summary__action--calendar {
+  color: #ff9800;
+}
+
+.home-summary--clients .home-summary__icon {
+  color: #4caf50;
+}
+
+.home-summary__action--clients {
+  color: #4caf50;
+}
+
+.home-summary--contacts .home-summary__icon {
+  color: #42a5f5;
+}
+
+.home-summary__metric--delayed .home-summary__label,
+.home-summary__metric--delayed .home-summary__value-bubble {
+  color: #ff5f5f;
+}
+
 .topbar__button {
   height: 35px;
   padding: 0 18px;


### PR DESCRIPTION
## Summary
- add a new Home entry to the sidebar and top bar navigation
- build the Home dashboard with shortcut cards and summary metrics styled per requirements
- wire the Home shortcuts into the existing navigation flow and make Home the default view

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de86b050b083338c9c88771cacd377