### PR TITLE
Refine home dashboard and client filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,56 +138,14 @@
       </header>
       <main class="content">
         <section class="content__page home-page is-active" data-page="home">
-          <div class="home-page__shortcuts" aria-label="Acesso rápido às páginas">
-            <button
-              class="home-shortcut home-shortcut--calendar"
-              type="button"
-              data-page-target="calendario"
-            >
-              <span class="home-shortcut__icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="img" aria-label="Calendário">
-                  <rect x="3" y="4" width="18" height="17" rx="2"></rect>
-                  <line x1="3" y1="9" x2="21" y2="9"></line>
-                  <line x1="8" y1="2" x2="8" y2="6"></line>
-                  <line x1="16" y1="2" x2="16" y2="6"></line>
-                </svg>
-              </span>
-              <span class="home-shortcut__label">Calendário</span>
-            </button>
-            <button
-              class="home-shortcut home-shortcut--clients"
-              type="button"
-              data-page-target="clientes"
-            >
-              <span class="home-shortcut__icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="img" aria-label="Clientes">
-                  <circle cx="8" cy="8" r="3"></circle>
-                  <circle cx="16" cy="11" r="3"></circle>
-                  <path d="M3 19c0-2.7614 2.2386-5 5-5h0.5"></path>
-                  <path d="M12 19c0-2.7614 2.2386-5 5-5h1"></path>
-                </svg>
-              </span>
-              <span class="home-shortcut__label">Clientes</span>
-            </button>
-            <button
-              class="home-shortcut home-shortcut--contacts"
-              type="button"
-              data-page-target="contatos"
-            >
-              <span class="home-shortcut__icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="img" aria-label="Contatos">
-                  <rect x="3" y="4" width="18" height="14" rx="2"></rect>
-                  <polyline points="7,20 7,16 12,16 12,20"></polyline>
-                </svg>
-              </span>
-              <span class="home-shortcut__label">Contatos</span>
-            </button>
-          </div>
-
-          <div class="home-page__sections">
-            <article class="home-summary home-summary--calendar">
-              <header class="home-summary__header">
-                <span class="home-summary__icon" aria-hidden="true">
+          <div class="home-page__sections" aria-label="Resumo das páginas">
+            <div class="home-section home-section--calendar">
+              <button
+                class="home-shortcut home-shortcut--calendar"
+                type="button"
+                data-page-target="calendario"
+              >
+                <span class="home-shortcut__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" role="img" aria-label="Calendário">
                     <rect x="3" y="4" width="18" height="17" rx="2"></rect>
                     <line x1="3" y1="9" x2="21" y2="9"></line>
@@ -195,22 +153,32 @@
                     <line x1="16" y1="2" x2="16" y2="6"></line>
                   </svg>
                 </span>
-                <h2 class="home-summary__title">Calendário</h2>
-              </header>
-              <ul class="home-summary__metrics">
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Eventos pendentes</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-              </ul>
-              <button class="home-summary__action home-summary__action--calendar" type="button">
-                Adicionar evento
+                <span class="home-shortcut__label">Calendário</span>
               </button>
-            </article>
+              <div class="home-section__cards">
+                <div class="home-card" role="group" aria-label="Eventos pendentes">
+                  <span class="home-card__label">Eventos pendentes</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <button
+                  class="home-card home-card--action home-card--calendar"
+                  type="button"
+                >
+                  <span class="home-card__icon" aria-hidden="true">+</span>
+                  <span class="home-card__label">Adicionar evento</span>
+                </button>
+              </div>
+            </div>
 
-            <article class="home-summary home-summary--clients">
-              <header class="home-summary__header">
-                <span class="home-summary__icon" aria-hidden="true">
+            <div class="home-section home-section--clients">
+              <button
+                class="home-shortcut home-shortcut--clients"
+                type="button"
+                data-page-target="clientes"
+              >
+                <span class="home-shortcut__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" role="img" aria-label="Clientes">
                     <circle cx="8" cy="8" r="3"></circle>
                     <circle cx="16" cy="11" r="3"></circle>
@@ -218,52 +186,72 @@
                     <path d="M12 19c0-2.7614 2.2386-5 5-5h1"></path>
                   </svg>
                 </span>
-                <h2 class="home-summary__title">Clientes</h2>
-              </header>
-              <ul class="home-summary__metrics">
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Clientes cadastrados</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Clientes essa semana</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-              </ul>
-              <button class="home-summary__action home-summary__action--clients" type="button">
-                Adicionar cliente
+                <span class="home-shortcut__label">Clientes</span>
               </button>
-            </article>
+              <div class="home-section__cards">
+                <div class="home-card" role="group" aria-label="Clientes cadastrados">
+                  <span class="home-card__label">Clientes cadastrados</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <div class="home-card" role="group" aria-label="Clientes essa semana">
+                  <span class="home-card__label">Clientes essa semana</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <button
+                  class="home-card home-card--action home-card--clients"
+                  type="button"
+                >
+                  <span class="home-card__icon" aria-hidden="true">+</span>
+                  <span class="home-card__label">Adicionar cliente</span>
+                </button>
+              </div>
+            </div>
 
-            <article class="home-summary home-summary--contacts">
-              <header class="home-summary__header">
-                <span class="home-summary__icon" aria-hidden="true">
+            <div class="home-section home-section--contacts">
+              <button
+                class="home-shortcut home-shortcut--contacts"
+                type="button"
+                data-page-target="contatos"
+              >
+                <span class="home-shortcut__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" role="img" aria-label="Contatos">
                     <rect x="3" y="4" width="18" height="14" rx="2"></rect>
                     <polyline points="7,20 7,16 12,16 12,20"></polyline>
                   </svg>
                 </span>
-                <h2 class="home-summary__title">Contatos</h2>
-              </header>
-              <ul class="home-summary__metrics">
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Para essa semana</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Para esse mês</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-                <li class="home-summary__metric">
-                  <span class="home-summary__label">Concluídos esse mês</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-                <li class="home-summary__metric home-summary__metric--delayed">
-                  <span class="home-summary__label">Contatos atrasados</span>
-                  <span class="home-summary__value"><span class="home-summary__value-bubble">valor</span></span>
-                </li>
-              </ul>
-            </article>
+                <span class="home-shortcut__label">Contatos</span>
+              </button>
+              <div class="home-section__cards">
+                <div class="home-card" role="group" aria-label="Para essa semana">
+                  <span class="home-card__label">Para essa semana</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <div class="home-card" role="group" aria-label="Para esse mês">
+                  <span class="home-card__label">Para esse mês</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <div class="home-card" role="group" aria-label="Concluídos esse mês">
+                  <span class="home-card__label">Concluídos esse mês</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+                <div class="home-card home-card--delayed" role="group" aria-label="Contatos atrasados">
+                  <span class="home-card__label">Contatos atrasados</span>
+                  <span class="home-card__value"
+                    ><span class="home-card__value-bubble">valor</span></span
+                  >
+                </div>
+              </div>
+            </div>
           </div>
         </section>
         <section class="content__page" data-page="calendario">
@@ -321,7 +309,6 @@
           <div class="clients-page">
             <header class="clients-page__header">
               <h1 class="clients-page__title">Clientes</h1>
-              <p class="clients-page__subtitle">Cadastre novos clientes e utilize a busca para encontrar informações com rapidez.</p>
             </header>
             <div class="clients-table-card">
               <div class="clients-table-wrapper">

--- a/styles.css
+++ b/styles.css
@@ -208,28 +208,36 @@ body.modal-open {
   color: rgba(255, 255, 255, 0.75);
 }
 
+
 .content__page.home-page {
-  display: flex;
   flex-direction: column;
   gap: 32px;
   align-items: center;
 }
 
-.home-page__shortcuts {
+.home-page__sections {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 20px;
+  gap: 24px;
   width: 100%;
+}
+
+.home-section {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 18px;
+  width: min(100%, 280px);
 }
 
 .home-shortcut {
   background-color: #141414;
   border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  height: 100px;
-  min-width: 220px;
-  padding: 0 32px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  height: 150px;
+  width: 100%;
+  padding: 0 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -285,135 +293,100 @@ body.modal-open {
   color: #42a5f5;
 }
 
-.home-page__sections {
-  display: grid;
-  gap: 24px;
-  width: 100%;
-  justify-items: center;
-}
-
-.home-summary {
-  background-color: #141414;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 24px 32px;
-  width: min(100%, 720px);
+.home-section__cards {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  font-size: 20px;
-}
-
-.home-summary__header {
-  display: flex;
-  align-items: center;
   gap: 16px;
 }
 
-.home-summary__icon {
-  display: inline-flex;
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(255, 255, 255, 0.08);
-}
-
-.home-summary__icon svg {
-  width: 28px;
-  height: 28px;
-  stroke: currentColor;
-  stroke-width: 1.8;
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.home-summary__title {
-  font-size: 26px;
-  font-weight: 700;
-}
-
-.home-summary__metrics {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.home-summary__metric {
+.home-card {
+  background-color: #141414;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  height: 100px;
+  padding: 0 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 50px;
+  gap: 16px;
+  font-size: 18px;
+  font-weight: 500;
 }
 
-.home-summary__label {
+.home-card__label {
   color: rgba(255, 255, 255, 0.85);
 }
 
-.home-summary__value {
+.home-card__value {
   display: inline-flex;
 }
 
-.home-summary__value-bubble {
+.home-card__value-bubble {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 72px;
-  padding: 6px 16px;
+  padding: 8px 18px;
   border-radius: 999px;
-  background-color: #2c2c2c;
+  background-color: #1f1f1f;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   font-weight: 700;
   color: #ffffff;
 }
 
-.home-summary__action {
-  align-self: flex-start;
-  padding: 10px 22px;
-  border-radius: 999px;
-  border: 1px solid currentColor;
-  background-color: transparent;
-  font-size: 20px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.home-summary__action:hover,
-.home-summary__action:focus-visible {
-  background-color: currentColor;
-  color: #141414;
-}
-
-.home-summary--calendar .home-summary__label {
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.home-summary--calendar .home-summary__icon {
-  color: #ff9800;
-}
-
-.home-summary__action--calendar {
-  color: #ff9800;
-}
-
-.home-summary--clients .home-summary__icon {
-  color: #4caf50;
-}
-
-.home-summary__action--clients {
-  color: #4caf50;
-}
-
-.home-summary--contacts .home-summary__icon {
-  color: #42a5f5;
-}
-
-.home-summary__metric--delayed .home-summary__label,
-.home-summary__metric--delayed .home-summary__value-bubble {
+.home-card--delayed .home-card__label,
+.home-card--delayed .home-card__value-bubble {
   color: #ff5f5f;
+  border-color: rgba(255, 95, 95, 0.35);
+}
+
+
+.home-card--action {
+  border-width: 2px;
+  border-style: solid;
+  background-color: #141414;
+  justify-content: center;
+  gap: 10px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-card--action .home-card__label {
+  color: currentColor;
+}
+
+.home-card--action:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 4px;
+}
+
+.home-card--action:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 18px rgba(0, 0, 0, 0.3);
+}
+
+.home-card__icon {
+  font-size: 32px;
+  line-height: 1;
+  font-weight: 600;
+  color: currentColor;
+}
+
+.home-card--calendar {
+  color: #ff9800;
+  border-color: #ff9800;
+}
+
+.home-card--clients {
+  color: #4caf50;
+  border-color: #4caf50;
+}
+
+.home-card--contacts {
+  color: #42a5f5;
+  border-color: #42a5f5;
 }
 
 .topbar__button {
@@ -1008,11 +981,6 @@ body.modal-open {
   margin-bottom: 2px;
 }
 
-.clients-page__subtitle {
-  font-size: 15px;
-  color: rgba(255, 255, 255, 0.75);
-}
-
 .clients-table-card {
   background-color: #1a1a1a;
   border-radius: 18px;
@@ -1126,7 +1094,7 @@ body.modal-open {
 
 .clients-table__filter,
 .clients-table__filter-group .clients-table__filter {
-  width: 100%;
+  width: min(100%, 140px);
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 10px;
   padding: 6px 10px;
@@ -1134,7 +1102,8 @@ body.modal-open {
   color: #ffffff;
   font-size: 12px;
   font-family: inherit;
-  margin-top: 10px;
+  margin-top: 8px;
+  transition: width 0.25s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .clients-table__filter::placeholder {
@@ -1145,25 +1114,25 @@ body.modal-open {
   outline: none;
   border-color: #ff9800;
   box-shadow: 0 0 0 2px rgba(255, 152, 0, 0.25);
+  width: min(100%, 220px);
 }
 
 .clients-table__filter-group {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 .clients-table__filter-group .clients-table__filter {
-  margin-top: 10px;
-  flex: 1;
-  min-width: 0;
-  width: auto;
+  margin-top: 8px;
+  flex: none;
 }
 
 .clients-table__filter-separator {
   color: rgba(255, 255, 255, 0.35);
   font-size: 12px;
-  margin-top: 10px;
+  margin-top: 12px;
 }
 
 .clients-table__body {


### PR DESCRIPTION
## Summary
- restructure the home dashboard so each shortcut owns its cards and the home view only shows on its page
- style the new cards and action buttons with increased shortcut height and accented borders plus icons
- clean up the clients header and make all filters compact until focused for better consistency

## Testing
- Manual check of home and clients pages

------
https://chatgpt.com/codex/tasks/task_e_68de8ed1aa608333ba2d81fd3617d268