### PR TITLE
Update home and clients page styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,7 @@
         <div class="topbar__title" aria-live="polite">HOME</div>
         <div class="topbar__menus">
           <div class="topbar__menu is-active" data-page="home">
-            <div class="topbar__group topbar__group--left home-topbar__group">
-              <p class="home-topbar__text">Bem-vindo ao seu painel geral.</p>
-            </div>
+            <div class="topbar__group topbar__group--left home-topbar__group"></div>
           </div>
           <div class="topbar__menu" data-page="calendario">
             <div class="topbar__group topbar__group--right">
@@ -159,7 +157,7 @@
                 <div class="home-card" role="group" aria-label="Eventos pendentes">
                   <span class="home-card__label">Eventos pendentes</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <button
@@ -192,13 +190,13 @@
                 <div class="home-card" role="group" aria-label="Clientes cadastrados">
                   <span class="home-card__label">Clientes cadastrados</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <div class="home-card" role="group" aria-label="Clientes essa semana">
                   <span class="home-card__label">Clientes essa semana</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <button
@@ -229,25 +227,25 @@
                 <div class="home-card" role="group" aria-label="Para essa semana">
                   <span class="home-card__label">Para essa semana</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <div class="home-card" role="group" aria-label="Para esse mês">
                   <span class="home-card__label">Para esse mês</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <div class="home-card" role="group" aria-label="Concluídos esse mês">
                   <span class="home-card__label">Concluídos esse mês</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
                 <div class="home-card home-card--delayed" role="group" aria-label="Contatos atrasados">
                   <span class="home-card__label">Contatos atrasados</span>
                   <span class="home-card__value"
-                    ><span class="home-card__value-bubble">valor</span></span
+                    ><span class="home-card__value-bubble">0</span></span
                   >
                 </div>
               </div>
@@ -329,21 +327,21 @@
                             <span class="clients-table__sort-icon" aria-hidden="true"></span>
                           </button>
                         </div>
-                        <input class="clients-table__filter" type="text" data-filter="name" placeholder="Filtrar por nome" />
+                        <input class="clients-table__filter" type="text" data-filter="name" />
                         <span class="clients-table__resizer" data-resize="name" aria-hidden="true"></span>
                       </th>
                       <th scope="col" class="clients-table__column" data-column-id="cpf">
                         <div class="clients-table__header">
                           <span class="clients-table__label">C.P.F</span>
                         </div>
-                        <input class="clients-table__filter" type="text" data-filter="cpf" placeholder="Filtrar por CPF" />
+                        <input class="clients-table__filter" type="text" data-filter="cpf" />
                         <span class="clients-table__resizer" data-resize="cpf" aria-hidden="true"></span>
                       </th>
                       <th scope="col" class="clients-table__column" data-column-id="phone">
                         <div class="clients-table__header">
                           <span class="clients-table__label">Telefone</span>
                         </div>
-                        <input class="clients-table__filter" type="text" data-filter="phone" placeholder="Filtrar por telefone" />
+                        <input class="clients-table__filter" type="text" data-filter="phone" />
                         <span class="clients-table__resizer" data-resize="phone" aria-hidden="true"></span>
                       </th>
                       <th scope="col" class="clients-table__column" data-column-id="gender">
@@ -353,7 +351,7 @@
                             <span class="clients-table__sort-icon" aria-hidden="true"></span>
                           </button>
                         </div>
-                        <input class="clients-table__filter" type="text" data-filter="gender" placeholder="M ou F" maxlength="1" />
+                        <input class="clients-table__filter" type="text" data-filter="gender" maxlength="1" />
                         <span class="clients-table__resizer" data-resize="gender" aria-hidden="true"></span>
                       </th>
                       <th scope="col" class="clients-table__column" data-column-id="age">
@@ -364,9 +362,9 @@
                           </button>
                         </div>
                         <div class="clients-table__filter-group">
-                          <input class="clients-table__filter" type="number" data-filter="age-min" placeholder="Mín" min="0" />
+                          <input class="clients-table__filter" type="number" data-filter="age-min" min="0" />
                           <span class="clients-table__filter-separator">-</span>
-                          <input class="clients-table__filter" type="number" data-filter="age-max" placeholder="Máx" min="0" />
+                          <input class="clients-table__filter" type="number" data-filter="age-max" min="0" />
                         </div>
                         <span class="clients-table__resizer" data-resize="age" aria-hidden="true"></span>
                       </th>
@@ -378,8 +376,8 @@
                           </button>
                         </div>
                         <div class="clients-table__filter-group">
-                          <input class="clients-table__filter" type="text" data-filter="lastPurchase-start" placeholder="De (dd/mm/aa)" />
-                          <input class="clients-table__filter" type="text" data-filter="lastPurchase-end" placeholder="Até (dd/mm/aa)" />
+                          <input class="clients-table__filter" type="text" data-filter="lastPurchase-start" />
+                          <input class="clients-table__filter" type="text" data-filter="lastPurchase-end" />
                         </div>
                         <span class="clients-table__resizer" data-resize="lastPurchase" aria-hidden="true"></span>
                       </th>
@@ -390,7 +388,7 @@
                             <span class="clients-table__sort-icon" aria-hidden="true"></span>
                           </button>
                         </div>
-                        <input class="clients-table__filter" type="text" data-filter="acceptsContact" placeholder="Sim ou Não" />
+                        <input class="clients-table__filter" type="text" data-filter="acceptsContact" />
                         <span class="clients-table__resizer" data-resize="acceptsContact" aria-hidden="true"></span>
                       </th>
                     </tr>

--- a/styles.css
+++ b/styles.css
@@ -234,18 +234,20 @@ body.modal-open {
 .home-shortcut {
   background-color: #141414;
   border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 2px solid currentColor;
   height: 150px;
   width: 100%;
-  padding: 0 28px;
+  padding: 24px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  font-size: 30px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  text-transform: capitalize;
+  gap: 12px;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  text-align: center;
   transition: transform 0.2s ease;
   cursor: pointer;
   font-family: inherit;
@@ -303,7 +305,7 @@ body.modal-open {
   background-color: #141414;
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  height: 100px;
+  height: 70px;
   padding: 0 24px;
   display: flex;
   align-items: center;
@@ -1033,6 +1035,7 @@ body.modal-open {
 
 .clients-table__label {
   white-space: nowrap;
+  font-size: 20px;
 }
 
 .clients-table__sort {
@@ -1094,7 +1097,7 @@ body.modal-open {
 
 .clients-table__filter,
 .clients-table__filter-group .clients-table__filter {
-  width: min(100%, 140px);
+  width: min(100%, 120px);
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 10px;
   padding: 6px 10px;
@@ -1114,25 +1117,25 @@ body.modal-open {
   outline: none;
   border-color: #ff9800;
   box-shadow: 0 0 0 2px rgba(255, 152, 0, 0.25);
-  width: min(100%, 220px);
+  width: min(100%, 160px);
 }
 
 .clients-table__filter-group {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 6px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .clients-table__filter-group .clients-table__filter {
-  margin-top: 8px;
-  flex: none;
+  margin-top: 0;
+  flex: 1 1 auto;
 }
 
 .clients-table__filter-separator {
   color: rgba(255, 255, 255, 0.35);
   font-size: 12px;
-  margin-top: 12px;
+  margin-top: 0;
 }
 
 .clients-table__body {


### PR DESCRIPTION
## Summary
- restyled the home shortcuts with colored borders, vertical icon layout, and zero placeholders in the summary cards
- tightened the home summary cards height and removed the welcome helper text
- increased the clients table header typography and simplified filters so they line up on a single row

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68debd7b47d88333afbfac357d54b1e1