### PR TITLE
Add contact workflow tabs and client detail enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,13 +168,55 @@
             <div class="topbar__group topbar__group--right"></div>
           </div>
           <div class="topbar__menu" data-page="contatos">
-            <div class="topbar__group topbar__group--left">
-              <button class="topbar__button topbar__button--green">
-                Novo Contato
+            <div
+              class="topbar__group topbar__group--full contacts-topbar"
+              role="tablist"
+              aria-label="Seções de contato"
+            >
+              <button
+                class="topbar__button topbar__button--tab is-active"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                id="contacts-tab-button-abertos"
+                aria-controls="contacts-tab-abertos"
+                data-contact-tab="abertos"
+              >
+                Contatos em Aberto
               </button>
-            </div>
-            <div class="topbar__group topbar__group--right">
-              <button class="topbar__button">Histórico</button>
+              <button
+                class="topbar__button topbar__button--tab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                id="contacts-tab-button-pos-venda"
+                aria-controls="contacts-tab-pos-venda"
+                data-contact-tab="pos-venda"
+              >
+                Pós-venda
+              </button>
+              <button
+                class="topbar__button topbar__button--tab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                id="contacts-tab-button-ofertas"
+                aria-controls="contacts-tab-ofertas"
+                data-contact-tab="ofertas"
+              >
+                Ofertas
+              </button>
+              <button
+                class="topbar__button topbar__button--tab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                id="contacts-tab-button-historico"
+                aria-controls="contacts-tab-historico"
+                data-contact-tab="historico"
+              >
+                Histórico de Contatos
+              </button>
             </div>
           </div>
           <div class="topbar__menu" data-page="configuracao">
@@ -528,12 +570,48 @@
                     <dd data-client-field="age">-</dd>
                   </div>
                   <div class="client-card__item">
+                    <dt>Usuário de</dt>
+                    <dd data-client-field="userType">-</dd>
+                  </div>
+                  <div class="client-card__item">
+                    <dt>Estado do cliente</dt>
+                    <dd>
+                      <span class="client-status-badge" data-client-field="state">-</span>
+                    </dd>
+                  </div>
+                  <div class="client-card__item">
                     <dt>Aceita contato</dt>
                     <dd data-client-field="acceptsContact">-</dd>
                   </div>
                 </dl>
               </article>
-              <article class="client-card">
+              <article class="client-card client-card--interests">
+                <header class="client-card__header">
+                  <h2 class="client-card__title">Interesses</h2>
+                  <div class="client-card__actions">
+                    <button
+                      class="client-card__action-button"
+                      type="button"
+                      aria-label="Adicionar interesse"
+                      title="Adicionar interesse"
+                    >
+                      +
+                    </button>
+                    <button
+                      class="client-card__action-button"
+                      type="button"
+                      aria-label="Editar interesses"
+                      title="Editar interesses"
+                    >
+                      ✎
+                    </button>
+                  </div>
+                </header>
+                <div class="client-interests">
+                  <div class="client-interests__list" data-role="client-interests"></div>
+                </div>
+              </article>
+              <article class="client-card client-card--purchases">
                 <header class="client-card__header">
                   <h2 class="client-card__title">Histórico de compras</h2>
                 </header>
@@ -575,8 +653,26 @@
                   </select>
                 </label>
                 <label class="client-form__field">
+                  <span class="client-form__label">Usuário de</span>
+                  <select name="userType" required>
+                    <option value="">Selecione</option>
+                    <option value="MF">M.F</option>
+                    <option value="BF">B.F</option>
+                    <option value="VS">V.S</option>
+                  </select>
+                </label>
+                <label class="client-form__field">
                   <span class="client-form__label">Data de nascimento</span>
                   <input type="date" name="birthDate" required />
+                </label>
+                <label class="client-form__field">
+                  <span class="client-form__label">Estado do cliente</span>
+                  <select name="state" required>
+                    <option value="">Selecione</option>
+                    <option value="pos-venda">Pós-venda</option>
+                    <option value="oferta">Oferta</option>
+                    <option value="nao-contatar">Não contatar</option>
+                  </select>
                 </label>
                 <label class="client-form__field client-form__field--checkbox">
                   <input type="checkbox" name="acceptsContact" />
@@ -595,6 +691,16 @@
                 <label class="client-form__field">
                   <span class="client-form__label">Armação</span>
                   <input type="text" name="frame" required />
+                </label>
+                <label class="client-form__field">
+                  <span class="client-form__label">Material da armação</span>
+                  <select name="frameMaterial" required>
+                    <option value="">Selecione</option>
+                    <option value="METAL">Metal</option>
+                    <option value="ACETATO">Acetato</option>
+                    <option value="TITANIUM">Titanium</option>
+                    <option value="OUTROS">Outros</option>
+                  </select>
                 </label>
                 <label class="client-form__field">
                   <span class="client-form__label">Valor da armação (R$)</span>
@@ -651,8 +757,139 @@
         </section>
 
         <section class="content__page" data-page="contatos">
-          <h1>Contatos</h1>
-          <p>Gerencie o histórico e crie novos contatos através das ações disponíveis no topo.</p>
+          <div class="contacts-page">
+            <section
+              class="contacts-subpage is-active"
+              data-contact-tab-content="abertos"
+              id="contacts-tab-abertos"
+              role="tabpanel"
+              aria-labelledby="contacts-tab-button-abertos"
+            >
+              <header class="contacts-subpage__header">
+                <div>
+                  <h1 class="contacts-subpage__title">Contatos em Aberto</h1>
+                  <p class="contacts-subpage__description">
+                    Acompanhe os contatos pendentes e conclua suas tarefas diárias.
+                  </p>
+                </div>
+                <div
+                  class="contacts-range-toggle"
+                  role="group"
+                  aria-label="Período da visualização"
+                >
+                  <button
+                    class="contacts-range-button is-active"
+                    type="button"
+                    data-range="weekly"
+                    aria-pressed="true"
+                  >
+                    Semanal
+                  </button>
+                  <button
+                    class="contacts-range-button"
+                    type="button"
+                    data-range="monthly"
+                    aria-pressed="false"
+                  >
+                    Mensal
+                  </button>
+                </div>
+              </header>
+              <div class="contacts-kanban" data-role="kanban-board">
+                <div class="contacts-kanban__column" data-status="abertos">
+                  <div class="contacts-kanban__header">
+                    <h2 class="contacts-kanban__title">Abertos</h2>
+                    <span class="contacts-kanban__count" data-column-count="abertos">0</span>
+                  </div>
+                  <div class="contacts-kanban__list" data-column="abertos"></div>
+                </div>
+                <div class="contacts-kanban__column" data-status="atrasados">
+                  <div class="contacts-kanban__header">
+                    <h2 class="contacts-kanban__title">Atrasados</h2>
+                    <span class="contacts-kanban__count" data-column-count="atrasados">0</span>
+                  </div>
+                  <div class="contacts-kanban__list" data-column="atrasados"></div>
+                </div>
+                <div class="contacts-kanban__column" data-status="concluidos">
+                  <div class="contacts-kanban__header">
+                    <h2 class="contacts-kanban__title">Concluídos</h2>
+                    <span class="contacts-kanban__count" data-column-count="concluidos">0</span>
+                  </div>
+                  <div class="contacts-kanban__list" data-column="concluidos"></div>
+                </div>
+              </div>
+            </section>
+
+            <section
+              class="contacts-subpage"
+              data-contact-tab-content="pos-venda"
+              id="contacts-tab-pos-venda"
+              role="tabpanel"
+              aria-labelledby="contacts-tab-button-pos-venda"
+              aria-hidden="true"
+            >
+              <header class="contacts-subpage__header">
+                <div>
+                  <h1 class="contacts-subpage__title">Pós-venda</h1>
+                  <p class="contacts-subpage__description">
+                    Revise entregas recentes, agende ajustes e fortaleça o relacionamento com os clientes.
+                  </p>
+                </div>
+              </header>
+              <ul class="contacts-stack" data-role="post-sale-list"></ul>
+            </section>
+
+            <section
+              class="contacts-subpage"
+              data-contact-tab-content="ofertas"
+              id="contacts-tab-ofertas"
+              role="tabpanel"
+              aria-labelledby="contacts-tab-button-ofertas"
+              aria-hidden="true"
+            >
+              <header class="contacts-subpage__header">
+                <div>
+                  <h1 class="contacts-subpage__title">Ofertas</h1>
+                  <p class="contacts-subpage__description">
+                    Planeje campanhas personalizadas e destaque produtos estratégicos para cada cliente.
+                  </p>
+                </div>
+              </header>
+              <div class="contacts-offers" data-role="offers-list"></div>
+            </section>
+
+            <section
+              class="contacts-subpage"
+              data-contact-tab-content="historico"
+              id="contacts-tab-historico"
+              role="tabpanel"
+              aria-labelledby="contacts-tab-button-historico"
+              aria-hidden="true"
+            >
+              <header class="contacts-subpage__header">
+                <div>
+                  <h1 class="contacts-subpage__title">Histórico de Contatos</h1>
+                  <p class="contacts-subpage__description">
+                    Consulte rapidamente os registros anteriores e acompanhe o status de cada atendimento.
+                  </p>
+                </div>
+              </header>
+              <div class="contacts-history">
+                <table class="contacts-history__table" aria-label="Histórico de contatos">
+                  <thead>
+                    <tr>
+                      <th scope="col">Nome</th>
+                      <th scope="col">NFe</th>
+                      <th scope="col">Data da compra</th>
+                      <th scope="col">Data do contato</th>
+                      <th scope="col">Completo</th>
+                    </tr>
+                  </thead>
+                  <tbody data-role="contacts-history-body"></tbody>
+                </table>
+              </div>
+            </section>
+          </div>
         </section>
         <section class="content__page" data-page="configuracao">
           <h1>Configuração</h1>
@@ -798,6 +1035,7 @@
     <script src="scripts/modals.js"></script>
     <script src="scripts/navigation.js"></script>
     <script src="scripts/clients.js"></script>
+    <script src="scripts/contacts.js"></script>
     <script src="scripts/init.js"></script>
   </body>
 </html>

--- a/scripts/contacts.js
+++ b/scripts/contacts.js
@@ -1,0 +1,499 @@
+'use strict';
+
+(function initializeContactsPage() {
+  const contactsPage = document.querySelector('.content__page[data-page="contatos"]');
+  if (!contactsPage) {
+    return;
+  }
+
+  const tabButtons = document.querySelectorAll('[data-contact-tab]');
+  const tabPanels = contactsPage.querySelectorAll('[data-contact-tab-content]');
+  const rangeButtons = contactsPage.querySelectorAll('.contacts-range-button');
+  const kanbanBoard = contactsPage.querySelector('[data-role="kanban-board"]');
+  const kanbanColumns = {
+    abertos: kanbanBoard?.querySelector('[data-column="abertos"]') ?? null,
+    atrasados: kanbanBoard?.querySelector('[data-column="atrasados"]') ?? null,
+    concluidos: kanbanBoard?.querySelector('[data-column="concluidos"]') ?? null,
+  };
+  const kanbanCounters = {
+    abertos: kanbanBoard?.querySelector('[data-column-count="abertos"]') ?? null,
+    atrasados: kanbanBoard?.querySelector('[data-column-count="atrasados"]') ?? null,
+    concluidos: kanbanBoard?.querySelector('[data-column-count="concluidos"]') ?? null,
+  };
+  const postSaleList = contactsPage.querySelector('[data-role="post-sale-list"]');
+  const offersList = contactsPage.querySelector('[data-role="offers-list"]');
+  const historyTableBody = contactsPage.querySelector('[data-role="contacts-history-body"]');
+
+  const STATUS_BADGE_CLASS = {
+    abertos: 'contacts-badge contacts-badge--due',
+    atrasados: 'contacts-badge contacts-badge--late',
+    concluidos: 'contacts-badge contacts-badge--done',
+  };
+
+  const KANBAN_ITEMS = [
+    {
+      id: 'kb-001',
+      clientId: 'cli-005',
+      title: 'Agendar retorno para ajuste de armação',
+      description: 'Cliente retirou o óculos há 5 dias, verificar conforto na armação.',
+      status: 'abertos',
+      dueDate: '2024-07-02',
+      cadence: 'weekly',
+    },
+    {
+      id: 'kb-002',
+      clientId: 'cli-018',
+      title: 'Confirmar entrega da lente multifocal',
+      description: 'Validar se o cliente recebeu e se adaptou bem à lente multifocal.',
+      status: 'abertos',
+      dueDate: '2024-07-03',
+      cadence: 'weekly',
+    },
+    {
+      id: 'kb-003',
+      clientId: 'cli-026',
+      title: 'Contato pós-venda 30 dias',
+      description: 'Reforçar orientações de limpeza e manutenção da armação.',
+      status: 'concluidos',
+      dueDate: '2024-06-25',
+      cadence: 'monthly',
+    },
+    {
+      id: 'kb-004',
+      clientId: 'cli-012',
+      title: 'Resolver troca de estojo',
+      description: 'Cliente solicitou troca do estojo por defeito na costura.',
+      status: 'atrasados',
+      dueDate: '2024-06-28',
+      cadence: 'weekly',
+    },
+    {
+      id: 'kb-005',
+      clientId: 'cli-033',
+      title: 'Apresentar nova linha solar',
+      description: 'Enviar catálogo digital das armações solares premium.',
+      status: 'abertos',
+      dueDate: '2024-07-10',
+      cadence: 'monthly',
+    },
+    {
+      id: 'kb-006',
+      clientId: 'cli-041',
+      title: 'Registrar satisfação da manutenção',
+      description: 'Cliente realizou manutenção preventiva, coletar feedback.',
+      status: 'concluidos',
+      dueDate: '2024-06-20',
+      cadence: 'all',
+    },
+  ];
+
+  const POST_SALE_ITEMS = [
+    {
+      id: 'ps-001',
+      clientId: 'cli-017',
+      title: 'Ajuste de plaquetas',
+      notes: 'Verificar se o ajuste das plaquetas ficou confortável após a entrega.',
+      dueDate: '2024-07-04',
+    },
+    {
+      id: 'ps-002',
+      clientId: 'cli-022',
+      title: 'Lembrar revisão de 6 meses',
+      notes: 'Enviar mensagem sugerindo revisão de limpeza ultrassônica.',
+      dueDate: '2024-07-08',
+    },
+    {
+      id: 'ps-003',
+      clientId: 'cli-009',
+      title: 'Follow-up lentes digitais',
+      notes: 'Confirmar adaptação às lentes com filtro azul e coletar opinião.',
+      dueDate: '2024-07-06',
+    },
+  ];
+
+  const OFFER_ITEMS = [
+    {
+      id: 'of-001',
+      clientId: 'cli-003',
+      product: 'Coleção Solar 2024',
+      value: 890,
+      expiresAt: '2024-07-15',
+    },
+    {
+      id: 'of-002',
+      clientId: 'cli-028',
+      product: 'Relógio Equal Chronos',
+      value: 1250,
+      expiresAt: '2024-07-22',
+    },
+    {
+      id: 'of-003',
+      clientId: 'cli-045',
+      product: 'Upgrade de lente multifocal premium',
+      value: 640,
+      expiresAt: '2024-07-30',
+    },
+    {
+      id: 'of-004',
+      clientId: 'cli-014',
+      product: 'Coleção Jóias Modernas',
+      value: 980,
+      expiresAt: '2024-07-18',
+    },
+  ];
+
+  const CONTACT_HISTORY = [
+    {
+      id: 'hist-001',
+      clientId: 'cli-005',
+      invoice: 'NF-CLI-005-123',
+      purchaseDate: '2024-05-30',
+      contactDate: '2024-06-05',
+      completed: true,
+    },
+    {
+      id: 'hist-002',
+      clientId: 'cli-018',
+      invoice: 'NF-CLI-018-111',
+      purchaseDate: '2024-06-01',
+      contactDate: '2024-06-15',
+      completed: false,
+    },
+    {
+      id: 'hist-003',
+      clientId: 'cli-026',
+      invoice: 'NF-CLI-026-137',
+      purchaseDate: '2024-05-06',
+      contactDate: '2024-06-06',
+      completed: true,
+    },
+    {
+      id: 'hist-004',
+      clientId: 'cli-033',
+      invoice: 'NF-CLI-033-142',
+      purchaseDate: '2024-04-21',
+      contactDate: '2024-05-02',
+      completed: true,
+    },
+    {
+      id: 'hist-005',
+      clientId: 'cli-041',
+      invoice: 'NF-CLI-041-128',
+      purchaseDate: '2024-05-08',
+      contactDate: '2024-06-01',
+      completed: false,
+    },
+  ];
+
+  const dateFormatter = new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+  });
+
+  let currentRange = 'weekly';
+
+  rangeButtons.forEach((button) => {
+    const isActive = button.dataset.range === currentRange;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+
+  function findClient(clientId) {
+    if (!clientId || typeof CLIENTS === 'undefined' || !Array.isArray(CLIENTS)) {
+      return null;
+    }
+    return CLIENTS.find((client) => client.id === clientId) ?? null;
+  }
+
+  function getClientName(clientId) {
+    const client = findClient(clientId);
+    return client?.name ?? 'Cliente';
+  }
+
+  function formatDate(dateString) {
+    const parsed = dateString ? new Date(`${dateString}T00:00:00`) : null;
+    if (!parsed || Number.isNaN(parsed.getTime())) {
+      return '-';
+    }
+    return dateFormatter.format(parsed);
+  }
+
+  function formatCurrency(value) {
+    return currencyFormatter.format(Number(value) || 0);
+  }
+
+  function createClientLink(label, clientId, className = '') {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.className = className;
+    element.textContent = label;
+    element.dataset.clientLink = 'true';
+    element.dataset.clientId = clientId;
+    return element;
+  }
+
+  function createKanbanCard(item) {
+    const card = document.createElement('article');
+    card.className = 'contacts-card';
+
+    const title = document.createElement('h3');
+    title.className = 'contacts-card__title';
+    title.textContent = item.title;
+
+    const clientButton = createClientLink(getClientName(item.clientId), item.clientId, 'contacts-card__client');
+
+    const description = document.createElement('p');
+    description.className = 'contacts-card__description';
+    description.textContent = item.description;
+
+    const meta = document.createElement('div');
+    meta.className = 'contacts-card__meta';
+
+    const badge = document.createElement('span');
+    badge.className = STATUS_BADGE_CLASS[item.status] ?? 'contacts-badge';
+    badge.textContent = item.status === 'concluidos' ? 'Concluído' : item.status === 'atrasados' ? 'Atrasado' : 'Em aberto';
+
+    const due = document.createElement('time');
+    due.dateTime = item.dueDate;
+    due.textContent = `Prazo: ${formatDate(item.dueDate)}`;
+
+    meta.append(badge, due);
+    card.append(title, clientButton, description, meta);
+    return card;
+  }
+
+  function renderKanban() {
+    Object.values(kanbanColumns).forEach((column) => {
+      if (column) {
+        column.innerHTML = '';
+      }
+    });
+
+    Object.entries(kanbanCounters).forEach(([, counter]) => {
+      if (counter) {
+        counter.textContent = '0';
+      }
+    });
+
+    if (!kanbanBoard) {
+      return;
+    }
+
+    const filteredItems = KANBAN_ITEMS.filter((item) => {
+      if (currentRange === 'monthly') {
+        return item.cadence === 'monthly' || item.cadence === 'all';
+      }
+      if (currentRange === 'weekly') {
+        return item.cadence === 'weekly' || item.cadence === 'all';
+      }
+      return true;
+    });
+
+    const counts = { abertos: 0, atrasados: 0, concluidos: 0 };
+
+    filteredItems.forEach((item) => {
+      const column = kanbanColumns[item.status];
+      if (!column) {
+        return;
+      }
+      counts[item.status] += 1;
+      column.appendChild(createKanbanCard(item));
+    });
+
+    Object.entries(kanbanColumns).forEach(([status, column]) => {
+      if (!column) {
+        return;
+      }
+      if (!column.children.length) {
+        const empty = document.createElement('p');
+        empty.className = 'contacts-kanban__empty';
+        empty.textContent = 'Nenhum contato registrado.';
+        column.appendChild(empty);
+      }
+    });
+
+    Object.entries(counts).forEach(([status, count]) => {
+      const counter = kanbanCounters[status];
+      if (counter) {
+        counter.textContent = String(count);
+      }
+    });
+  }
+
+  function renderPostSale() {
+    if (!postSaleList) {
+      return;
+    }
+    postSaleList.innerHTML = '';
+    POST_SALE_ITEMS.forEach((item) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'contacts-stack__item';
+
+      const header = document.createElement('div');
+      header.className = 'contacts-stack__header';
+      const title = document.createElement('h3');
+      title.className = 'contacts-stack__title';
+      title.textContent = item.title;
+      const badge = document.createElement('span');
+      badge.className = 'contacts-badge contacts-badge--due';
+      badge.textContent = formatDate(item.dueDate);
+      header.append(title, badge);
+
+      const clientButton = createClientLink(getClientName(item.clientId), item.clientId, 'contacts-card__client');
+
+      const body = document.createElement('p');
+      body.className = 'contacts-stack__body';
+      body.textContent = item.notes;
+
+      listItem.append(header, clientButton, body);
+      postSaleList.appendChild(listItem);
+    });
+  }
+
+  function renderOffers() {
+    if (!offersList) {
+      return;
+    }
+    offersList.innerHTML = '';
+    OFFER_ITEMS.forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'contacts-offer';
+
+      const title = document.createElement('h3');
+      title.className = 'contacts-offer__title';
+      title.textContent = item.product;
+
+      const meta = document.createElement('div');
+      meta.className = 'contacts-offer__meta';
+
+      const clientWrapper = document.createElement('div');
+      clientWrapper.textContent = 'Cliente: ';
+      const clientLink = createClientLink(getClientName(item.clientId), item.clientId, 'contacts-card__client');
+      clientWrapper.appendChild(clientLink);
+
+      const value = document.createElement('div');
+      value.textContent = `Oferta: ${formatCurrency(item.value)}`;
+
+      const expires = document.createElement('div');
+      expires.textContent = `Válido até: ${formatDate(item.expiresAt)}`;
+
+      meta.append(clientWrapper, value, expires);
+      card.append(title, meta);
+      offersList.appendChild(card);
+    });
+  }
+
+  function renderHistory() {
+    if (!historyTableBody) {
+      return;
+    }
+    historyTableBody.innerHTML = '';
+
+    CONTACT_HISTORY.forEach((item) => {
+      const row = document.createElement('tr');
+
+      const clientCell = document.createElement('td');
+      const link = document.createElement('a');
+      link.href = '#';
+      link.className = 'contacts-history__link';
+      link.dataset.clientLink = 'true';
+      link.dataset.clientId = item.clientId;
+      link.textContent = getClientName(item.clientId);
+      clientCell.appendChild(link);
+
+      const invoiceCell = document.createElement('td');
+      invoiceCell.textContent = item.invoice;
+
+      const purchaseCell = document.createElement('td');
+      purchaseCell.textContent = formatDate(item.purchaseDate);
+
+      const contactCell = document.createElement('td');
+      contactCell.textContent = formatDate(item.contactDate);
+
+      const statusCell = document.createElement('td');
+      const status = document.createElement('span');
+      status.className = item.completed
+        ? 'contacts-status-chip contacts-status-chip--yes'
+        : 'contacts-status-chip contacts-status-chip--no';
+      status.textContent = item.completed ? 'Sim' : 'Não';
+      statusCell.appendChild(status);
+
+      row.append(clientCell, invoiceCell, purchaseCell, contactCell, statusCell);
+      historyTableBody.appendChild(row);
+    });
+  }
+
+  function activateTab(tabName) {
+    tabButtons.forEach((button) => {
+      const isActive = button.dataset.contactTab === tabName;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', String(isActive));
+    });
+
+    tabPanels.forEach((panel) => {
+      const isActive = panel.dataset.contactTabContent === tabName;
+      panel.classList.toggle('is-active', isActive);
+      panel.setAttribute('aria-hidden', String(!isActive));
+    });
+  }
+
+  function setRange(range) {
+    if (currentRange === range) {
+      return;
+    }
+    currentRange = range;
+    rangeButtons.forEach((button) => {
+      const isActive = button.dataset.range === range;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
+    renderKanban();
+  }
+
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const tab = button.dataset.contactTab;
+      if (tab) {
+        activateTab(tab);
+      }
+    });
+  });
+
+  rangeButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const range = button.dataset.range;
+      if (range) {
+        setRange(range);
+      }
+    });
+  });
+
+  contactsPage.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const link = target.closest('[data-client-link]');
+    if (!link) {
+      return;
+    }
+    event.preventDefault();
+    const clientId = link.getAttribute('data-client-id');
+    if (!clientId || typeof window.navigateToClientDetail !== 'function') {
+      return;
+    }
+    window.navigateToClientDetail(clientId);
+  });
+
+  activateTab('abertos');
+  renderKanban();
+  renderPostSale();
+  renderOffers();
+  renderHistory();
+})();

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -35,5 +35,6 @@ const clientDetailDeleteButton = document.querySelector('[data-role="client-deta
 const clientDetailElement = document.querySelector('[data-role="client-detail"]');
 const clientDetailFields = clientDetailElement?.querySelectorAll('[data-client-field]');
 const clientPurchasesContainer = clientDetailElement?.querySelector('[data-role="client-purchases"]');
+const clientInterestsContainer = clientDetailElement?.querySelector('[data-role="client-interests"]');
 const clientFormElement = document.querySelector('#client-registration-form');
 const clientFormCancelButton = document.querySelector('[data-role="client-form-cancel"]');

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,17 @@ body.modal-open {
   gap: 12px;
 }
 
+.topbar__group--full {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.contacts-topbar {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .topbar__group--left {
   flex: 1;
   justify-content: center;
@@ -427,6 +438,29 @@ body.modal-open {
 .topbar__button.is-active {
   background-color: #eef1f3;
   color: #1a1a1a;
+}
+
+.topbar__button--tab {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  text-transform: none;
+  font-size: 15px;
+  min-height: 38px;
+  padding: 0 20px;
+}
+
+.topbar__button--tab:hover,
+.topbar__button--tab:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.topbar__button--tab.is-active {
+  background-color: #ff9800;
+  color: #0c0c0c;
+  border-color: #ff9800;
 }
 
 .topbar__search {
@@ -1323,9 +1357,329 @@ body.modal-open {
   .client-detail__cards {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .client-detail__cards .client-card:nth-child(2) {
+  .client-detail__cards .client-card--purchases {
     grid-column: span 2;
   }
+}
+
+.contacts-page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.contacts-subpage {
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.contacts-subpage.is-active {
+  display: flex;
+}
+
+.contacts-subpage__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.contacts-subpage__title {
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.contacts-subpage__description {
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 15px;
+  max-width: 640px;
+}
+
+.contacts-range-toggle {
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 14px;
+  background-color: rgba(255, 255, 255, 0.06);
+  gap: 6px;
+}
+
+.contacts-range-button {
+  border: none;
+  border-radius: 10px;
+  padding: 6px 16px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.contacts-range-button.is-active {
+  background-color: #ff9800;
+  color: #0c0c0c;
+}
+
+.contacts-range-button:hover,
+.contacts-range-button:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+}
+
+.contacts-kanban {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.contacts-kanban__column {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 260px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.contacts-kanban__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.contacts-kanban__title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.contacts-kanban__count {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.contacts-kanban__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.contacts-kanban__empty {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 14px;
+}
+
+.contacts-card {
+  background: #1a1a1a;
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.32);
+}
+
+.contacts-card__title {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.contacts-card__client {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #42a5f5;
+  font-size: 15px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.contacts-card__client:hover,
+.contacts-card__client:focus {
+  text-decoration: underline;
+  color: #64b5f6;
+}
+
+.contacts-card__description {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.contacts-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.contacts-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.contacts-badge--due {
+  background-color: rgba(255, 152, 0, 0.18);
+  color: #ffb74d;
+}
+
+.contacts-badge--late {
+  background-color: rgba(239, 83, 80, 0.18);
+  color: #ef9a9a;
+}
+
+.contacts-badge--done {
+  background-color: rgba(76, 175, 80, 0.18);
+  color: #a5d6a7;
+}
+
+.contacts-stack {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+}
+
+.contacts-stack__item {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.contacts-stack__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.contacts-stack__title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.contacts-stack__body {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.contacts-offers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.contacts-offer {
+  background: #1a1a1a;
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.contacts-offer__title {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.contacts-offer__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.contacts-history__table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.contacts-history__table th,
+.contacts-history__table td {
+  text-align: left;
+  padding: 14px 18px;
+  font-size: 14px;
+}
+
+.contacts-history__table thead {
+  background: rgba(255, 255, 255, 0.08);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 13px;
+}
+
+.contacts-history__table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.contacts-history__link {
+  color: #42a5f5;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.contacts-history__link:hover,
+.contacts-history__link:focus {
+  text-decoration: underline;
+  color: #64b5f6;
+}
+
+.contacts-status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.contacts-status-chip--yes {
+  background: rgba(76, 175, 80, 0.18);
+  color: #a5d6a7;
+}
+
+.contacts-status-chip--no {
+  background: rgba(244, 67, 54, 0.18);
+  color: #ef9a9a;
 }
 
 .client-card {
@@ -1342,6 +1696,32 @@ body.modal-open {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.client-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.client-card__action-button {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.client-card__action-button:hover,
+.client-card__action-button:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.22);
 }
 
 .client-card__title {
@@ -1374,6 +1754,62 @@ body.modal-open {
   font-size: 15px;
   color: rgba(255, 255, 255, 0.92);
   font-weight: 600;
+}
+
+.client-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.client-status-badge[data-state="pos-venda"] {
+  background: rgba(33, 150, 243, 0.18);
+  color: #90caf9;
+}
+
+.client-status-badge[data-state="oferta"] {
+  background: rgba(255, 193, 7, 0.18);
+  color: #ffe082;
+}
+
+.client-status-badge[data-state="nao-contatar"] {
+  background: rgba(244, 67, 54, 0.18);
+  color: #ef9a9a;
+}
+
+.client-interests {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.client-interests__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.client-interests__empty {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 14px;
+}
+
+.client-interest-tag {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  background: rgba(66, 165, 245, 0.18);
+  color: #90caf9;
 }
 
 .client-card__empty {


### PR DESCRIPTION
## Summary
- replace the contacts toolbar with tabbed navigation and build dedicated subpages for open work, pós-venda tasks, offers, and history
- introduce a reusable contacts.js module to populate kanban columns, post-sale tasks, offers, and the history table, linking entries back to client details
- expand client detail and form views with interests, user type/state selectors, and frame material support, refreshing styling to match

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dede09640c8333820169f168d8504c