### PR TITLE
Add SQLite storage layer with adapter architecture

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "better-sqlite3": "^9.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,87 +1,171 @@
 const express = require('express');
 const cors = require('cors');
-const dotenv = require('dotenv');
-const GoogleSheetsService = require('./services/googleSheetsService');
-
-dotenv.config();
+const storage = require('./src/storage');
+const { PORT, STORAGE } = require('./src/config/env');
 
 const app = express();
-const PORT = process.env.PORT || 4000;
 
 app.use(cors());
 app.use(express.json());
 
-const sheetsService = new GoogleSheetsService({
-  spreadsheetId: process.env.GOOGLE_SHEETS_SPREADSHEET_ID,
-  worksheetName: process.env.GOOGLE_SHEETS_WORKSHEET_NAME || 'Eventos',
-});
-
-function handleIntegrationError(res, error) {
-  const status = error.code === 'NOT_CONFIGURED' ? 503 : 500;
-  res.status(status).json({
-    error: error.message || 'Erro inesperado ao integrar com o Google Sheets.',
-    details: error.details || null,
-  });
+function toApiEvento(evento) {
+  return {
+    id: evento.id,
+    date: evento.data,
+    title: evento.titulo,
+    description: evento.descricao,
+    color: evento.cor,
+    clientId: evento.cliente_id,
+    createdAt: evento.created_at,
+  };
 }
 
-app.get('/api/health', async (req, res) => {
-  res.json({
-    status: 'ok',
-    googleSheetsConfigured: sheetsService.isConfigured(),
-  });
+function fromApiEvento(payload) {
+  return {
+    data: payload.date,
+    titulo: payload.title,
+    descricao: payload.description ?? null,
+    cor: payload.color ?? null,
+    cliente_id: payload.clientId ?? null,
+  };
+}
+
+function handleError(res, error) {
+  if (error?.code === 'NOT_IMPLEMENTED') {
+    return res.status(501).json({ error: error.message });
+  }
+
+  if (error?.code === 'NOT_CONFIGURED') {
+    return res.status(503).json({ error: error.message, details: error.details });
+  }
+
+  if (error?.code === 'NOT_FOUND') {
+    return res.status(404).json({ error: error.message });
+  }
+
+  return res.status(500).json({ error: error?.message || 'Erro interno do servidor.' });
+}
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok', storage: STORAGE });
+});
+
+app.get('/api/clients', async (req, res) => {
+  try {
+    const clientes = await Promise.resolve(storage.listClientes());
+    res.json({ clients: clientes });
+  } catch (error) {
+    handleError(res, error);
+  }
+});
+
+app.post('/api/clients', async (req, res) => {
+  try {
+    const { nome, telefone = null, email = null } = req.body || {};
+
+    if (!nome) {
+      return res.status(400).json({ error: 'Campo "nome" é obrigatório.' });
+    }
+
+    const cliente = await Promise.resolve(
+      storage.createCliente({ nome, telefone, email })
+    );
+
+    res.status(201).json({ client: cliente });
+  } catch (error) {
+    handleError(res, error);
+  }
+});
+
+app.put('/api/clients/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { nome, telefone, email } = req.body || {};
+    const updated = await Promise.resolve(
+      storage.updateCliente(id, { nome, telefone, email })
+    );
+
+    if (!updated) {
+      return res.status(404).json({ error: 'Cliente não encontrado.' });
+    }
+
+    res.json({ client: updated });
+  } catch (error) {
+    handleError(res, error);
+  }
+});
+
+app.delete('/api/clients/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const removed = await Promise.resolve(storage.deleteCliente(id));
+
+    if (!removed) {
+      return res.status(404).json({ error: 'Cliente não encontrado.' });
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    handleError(res, error);
+  }
 });
 
 app.get('/api/events', async (req, res) => {
   try {
-    const events = await sheetsService.listEvents();
-    res.json({ events });
+    const eventos = await Promise.resolve(storage.listEventos());
+    res.json({ events: eventos.map(toApiEvento) });
   } catch (error) {
-    handleIntegrationError(res, error);
+    handleError(res, error);
   }
 });
 
 app.post('/api/events', async (req, res) => {
-  const { date, title, description = '', userId = '' } = req.body || {};
+  const { date, title, description = null, color = null, clientId = null } =
+    req.body || {};
 
   if (!date || !title) {
-    return res.status(400).json({
-      error: 'Campos "date" e "title" são obrigatórios.',
-    });
+    return res
+      .status(400)
+      .json({ error: 'Campos "date" e "title" são obrigatórios.' });
   }
 
   try {
-    const createdEvent = await sheetsService.appendEvent({
-      date,
-      title,
-      description,
-      userId,
-    });
+    const created = await Promise.resolve(
+      storage.createEvento(
+        fromApiEvento({ date, title, description, color, clientId })
+      )
+    );
 
-    res.status(201).json({ event: createdEvent });
+    res.status(201).json({ event: toApiEvento(created) });
   } catch (error) {
-    handleIntegrationError(res, error);
+    handleError(res, error);
   }
 });
 
 app.put('/api/events/:id', async (req, res) => {
   const { id } = req.params;
-  const { date, title, description = '', userId = '' } = req.body || {};
+  const { date, title, description = null, color = null, clientId = null } =
+    req.body || {};
 
   if (!id) {
     return res.status(400).json({ error: 'O identificador do evento é obrigatório.' });
   }
 
   try {
-    const updatedEvent = await sheetsService.updateEvent(id, {
-      date,
-      title,
-      description,
-      userId,
-    });
+    const updated = await Promise.resolve(
+      storage.updateEvento(
+        id,
+        fromApiEvento({ date, title, description, color, clientId })
+      )
+    );
 
-    res.json({ event: updatedEvent });
+    if (!updated) {
+      return res.status(404).json({ error: 'Evento não encontrado.' });
+    }
+
+    res.json({ event: toApiEvento(updated) });
   } catch (error) {
-    handleIntegrationError(res, error);
+    handleError(res, error);
   }
 });
 
@@ -92,10 +176,14 @@ app.delete('/api/events/:id', async (req, res) => {
   }
 
   try {
-    await sheetsService.deleteEvent(id);
+    const removed = await Promise.resolve(storage.deleteEvento(id));
+    if (!removed) {
+      return res.status(404).json({ error: 'Evento não encontrado.' });
+    }
+
     res.status(204).send();
   } catch (error) {
-    handleIntegrationError(res, error);
+    handleError(res, error);
   }
 });
 

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const DEFAULT_PORT = 4000;
+const DEFAULT_STORAGE = 'sqlite';
+const DEFAULT_SQLITE_DB_PATH = '../data/crm.db';
+
+const rawPort = process.env.PORT;
+const rawStorage = process.env.STORAGE;
+const rawSqlitePath = process.env.SQLITE_DB_PATH || DEFAULT_SQLITE_DB_PATH;
+
+const PORT = rawPort ? Number(rawPort) : DEFAULT_PORT;
+const STORAGE = (rawStorage || DEFAULT_STORAGE).toLowerCase();
+const SQLITE_DB_PATH = path.isAbsolute(rawSqlitePath)
+  ? rawSqlitePath
+  : path.resolve(__dirname, '../../', rawSqlitePath);
+
+module.exports = {
+  PORT,
+  STORAGE,
+  SQLITE_DB_PATH,
+};

--- a/backend/src/storage/index.js
+++ b/backend/src/storage/index.js
@@ -1,0 +1,13 @@
+const { STORAGE } = require('../config/env');
+
+function resolveAdapter() {
+  switch (STORAGE) {
+    case 'sheets':
+      return require('./sheets');
+    case 'sqlite':
+    default:
+      return require('./sqlite');
+  }
+}
+
+module.exports = resolveAdapter();

--- a/backend/src/storage/sheets.js
+++ b/backend/src/storage/sheets.js
@@ -1,0 +1,66 @@
+const GoogleSheetsService = require('../../services/googleSheetsService');
+
+const sheetsService = new GoogleSheetsService({
+  spreadsheetId: process.env.GOOGLE_SHEETS_SPREADSHEET_ID,
+  worksheetName: process.env.GOOGLE_SHEETS_WORKSHEET_NAME || 'Eventos',
+});
+
+function unsupportedClientes() {
+  const error = new Error('Operação não suportada para o adaptador Google Sheets.');
+  error.code = 'NOT_IMPLEMENTED';
+  throw error;
+}
+
+function mapSheetEventToStorage(event) {
+  return {
+    id: event.id,
+    data: event.date,
+    titulo: event.title,
+    descricao: event.description,
+    cor: event.color ?? null,
+    cliente_id: event.userId ?? null,
+    created_at: event.createdAt ?? null,
+  };
+}
+
+function mapStorageEventToSheet(event) {
+  return {
+    id: event.id,
+    date: event.data,
+    title: event.titulo,
+    description: event.descricao,
+    userId: event.cliente_id,
+    color: event.cor,
+  };
+}
+
+module.exports = {
+  async listClientes() {
+    return unsupportedClientes();
+  },
+  async createCliente() {
+    return unsupportedClientes();
+  },
+  async updateCliente() {
+    return unsupportedClientes();
+  },
+  async deleteCliente() {
+    return unsupportedClientes();
+  },
+  async listEventos() {
+    const events = await sheetsService.listEvents();
+    return events.map(mapSheetEventToStorage);
+  },
+  async createEvento(evento) {
+    const created = await sheetsService.appendEvent(mapStorageEventToSheet(evento));
+    return mapSheetEventToStorage(created);
+  },
+  async updateEvento(id, evento) {
+    const updated = await sheetsService.updateEvent(id, mapStorageEventToSheet(evento));
+    return mapSheetEventToStorage(updated);
+  },
+  async deleteEvento(id) {
+    await sheetsService.deleteEvent(id);
+    return true;
+  },
+};

--- a/backend/src/storage/sqlite.js
+++ b/backend/src/storage/sqlite.js
@@ -1,0 +1,205 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+const { SQLITE_DB_PATH } = require('../config/env');
+
+const databasePath = SQLITE_DB_PATH;
+const databaseDir = path.dirname(databasePath);
+
+if (!fs.existsSync(databaseDir)) {
+  fs.mkdirSync(databaseDir, { recursive: true });
+}
+
+const db = new Database(databasePath);
+
+db.pragma('foreign_keys = ON');
+db.exec(`
+  CREATE TABLE IF NOT EXISTS clientes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome TEXT NOT NULL,
+    telefone TEXT,
+    email TEXT,
+    created_at TEXT
+  );
+`);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS eventos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    data TEXT NOT NULL,
+    titulo TEXT NOT NULL,
+    descricao TEXT,
+    cor TEXT,
+    cliente_id INTEGER,
+    created_at TEXT
+  );
+`);
+
+const listClientesStmt = db.prepare(
+  'SELECT id, nome, telefone, email, created_at FROM clientes ORDER BY id DESC'
+);
+
+const getClienteStmt = db.prepare(
+  'SELECT id, nome, telefone, email, created_at FROM clientes WHERE id = ?'
+);
+
+const insertClienteStmt = db.prepare(
+  'INSERT INTO clientes (nome, telefone, email, created_at) VALUES (?, ?, ?, ?)'
+);
+
+const updateClienteStmt = db.prepare(
+  'UPDATE clientes SET nome = ?, telefone = ?, email = ? WHERE id = ?'
+);
+
+const deleteClienteStmt = db.prepare('DELETE FROM clientes WHERE id = ?');
+
+const listEventosStmt = db.prepare(
+  `SELECT id, data, titulo, descricao, cor, cliente_id, created_at
+   FROM eventos
+   ORDER BY data DESC, id DESC`
+);
+
+const getEventoStmt = db.prepare(
+  `SELECT id, data, titulo, descricao, cor, cliente_id, created_at
+   FROM eventos
+   WHERE id = ?`
+);
+
+const insertEventoStmt = db.prepare(
+  `INSERT INTO eventos (data, titulo, descricao, cor, cliente_id, created_at)
+   VALUES (?, ?, ?, ?, ?, ?)`
+);
+
+const updateEventoStmt = db.prepare(
+  `UPDATE eventos
+   SET data = ?, titulo = ?, descricao = ?, cor = ?, cliente_id = ?
+   WHERE id = ?`
+);
+
+const deleteEventoStmt = db.prepare('DELETE FROM eventos WHERE id = ?');
+
+function listClientes() {
+  return listClientesStmt.all();
+}
+
+function createCliente({ nome, telefone = null, email = null }) {
+  if (!nome) {
+    throw new Error('Campo "nome" é obrigatório.');
+  }
+
+  const createdAt = new Date().toISOString();
+  const result = insertClienteStmt.run(nome, telefone, email, createdAt);
+  return getClienteStmt.get(result.lastInsertRowid);
+}
+
+function updateCliente(id, { nome, telefone, email }) {
+  const clienteId = Number(id);
+  if (Number.isNaN(clienteId)) {
+    return null;
+  }
+
+  const existing = getClienteStmt.get(clienteId);
+  if (!existing) {
+    return null;
+  }
+
+  const updated = {
+    nome: nome ?? existing.nome,
+    telefone: telefone ?? existing.telefone,
+    email: email ?? existing.email,
+  };
+
+  updateClienteStmt.run(updated.nome, updated.telefone, updated.email, clienteId);
+  return getClienteStmt.get(clienteId);
+}
+
+function deleteCliente(id) {
+  const clienteId = Number(id);
+  if (Number.isNaN(clienteId)) {
+    return false;
+  }
+
+  const result = deleteClienteStmt.run(clienteId);
+  return result.changes > 0;
+}
+
+function listEventos() {
+  return listEventosStmt.all();
+}
+
+function createEvento({
+  data,
+  titulo,
+  descricao = null,
+  cor = null,
+  cliente_id = null,
+}) {
+  if (!data || !titulo) {
+    throw new Error('Campos "data" e "titulo" são obrigatórios.');
+  }
+
+  const createdAt = new Date().toISOString();
+  const result = insertEventoStmt.run(
+    data,
+    titulo,
+    descricao,
+    cor,
+    cliente_id,
+    createdAt
+  );
+
+  return getEventoStmt.get(result.lastInsertRowid);
+}
+
+function updateEvento(id, { data, titulo, descricao, cor, cliente_id }) {
+  const eventoId = Number(id);
+  if (Number.isNaN(eventoId)) {
+    return null;
+  }
+
+  const existing = getEventoStmt.get(eventoId);
+  if (!existing) {
+    return null;
+  }
+
+  const updated = {
+    data: data ?? existing.data,
+    titulo: titulo ?? existing.titulo,
+    descricao: descricao ?? existing.descricao,
+    cor: cor ?? existing.cor,
+    cliente_id:
+      cliente_id === undefined ? existing.cliente_id : cliente_id,
+  };
+
+  updateEventoStmt.run(
+    updated.data,
+    updated.titulo,
+    updated.descricao,
+    updated.cor,
+    updated.cliente_id,
+    eventoId
+  );
+
+  return getEventoStmt.get(eventoId);
+}
+
+function deleteEvento(id) {
+  const eventoId = Number(id);
+  if (Number.isNaN(eventoId)) {
+    return false;
+  }
+
+  const result = deleteEventoStmt.run(eventoId);
+  return result.changes > 0;
+}
+
+module.exports = {
+  listClientes,
+  createCliente,
+  updateCliente,
+  deleteCliente,
+  listEventos,
+  createEvento,
+  updateEvento,
+  deleteEvento,
+};


### PR DESCRIPTION
## Summary
- add environment configuration helper to configure storage backends
- implement SQLite storage adapter with automatic table creation and adapter registry
- refactor server routes to use storage adapters and expose client CRUD endpoints

## Testing
- npm install *(fails: 403 Forbidden fetching better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68dfab74e3188333842378198a5702f8