### PR TITLE
feat: add clientes e eventos REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Para visualizar a interface basta servir a pasta `frontend` em um servidor está
 
 ## Backend
 
-O backend expõe endpoints REST para listar, criar, atualizar e remover eventos armazenados em uma planilha do Google Sheets.
+O backend expõe endpoints REST para gerenciar clientes e eventos. Os dados podem ser persistidos tanto em SQLite (padrão) quanto no Google Sheets, dependendo da configuração aplicada.
 
 ### Configuração
 
@@ -59,10 +59,51 @@ npm run dev
 A API ficará disponível em `http://localhost:4000`. Os endpoints principais são:
 
 - `GET /api/health` — verificação simples da integração.
-- `GET /api/events` — lista eventos existentes.
-- `POST /api/events` — adiciona um evento.
-- `PUT /api/events/:id` — atualiza um evento.
-- `DELETE /api/events/:id` — remove um evento.
+- `GET /api/clientes` — lista clientes cadastrados, com suporte a `?q=` (busca) e `?page=` (paginação).
+- `POST /api/clientes` — adiciona um novo cliente.
+- `PUT /api/clientes/:id` — atualiza os dados de um cliente existente.
+- `DELETE /api/clientes/:id` — remove um cliente.
+- `GET /api/eventos` — lista eventos existentes, permitindo filtrar por intervalo de datas com `?from=YYYY-MM-DD&to=YYYY-MM-DD`.
+- `POST /api/eventos` — adiciona um evento.
+- `PUT /api/eventos/:id` — atualiza um evento.
+- `DELETE /api/eventos/:id` — remove um evento.
+
+### Exemplos com `curl`
+
+```bash
+# Lista a segunda página de clientes contendo "ana" no nome, telefone ou e-mail.
+curl "http://localhost:4000/api/clientes?q=ana&page=2"
+
+# Cria um cliente
+curl -X POST "http://localhost:4000/api/clientes" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "nome": "Ana Souza",
+    "telefone": "+55 11 99999-9999",
+    "email": "ana@example.com"
+  }'
+
+# Atualiza apenas o telefone de um cliente
+curl -X PUT "http://localhost:4000/api/clientes/1" \
+  -H "Content-Type: application/json" \
+  -d '{ "telefone": "+55 11 98888-8888" }'
+
+# Busca eventos entre duas datas (intervalo inclusivo)
+curl "http://localhost:4000/api/eventos?from=2024-01-01&to=2024-12-31"
+
+# Cria um evento associado a um cliente
+curl -X POST "http://localhost:4000/api/eventos" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "date": "2024-06-15",
+    "title": "Reunião com Ana",
+    "description": "Apresentação do produto",
+    "clientId": 1
+  }'
+
+# Remove um evento
+curl -X DELETE "http://localhost:4000/api/eventos/3"
+```
 
 ## Integração futura
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "googleapis": "^131.0.0"
+    "googleapis": "^131.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,11 +1,26 @@
 const express = require('express');
 const cors = require('cors');
+const { z, ZodError } = require('zod');
 const storage = require('./src/storage');
 const { PORT, STORAGE } = require('./src/config/env');
 
 const app = express();
 
-app.use(cors());
+const corsOptions = {
+  origin(origin, callback) {
+    if (!origin) {
+      return callback(null, true);
+    }
+
+    if (/^http:\/\/localhost(?::\d+)?$/.test(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(new Error('Not allowed by CORS'));
+  },
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 function toApiEvento(evento) {
@@ -20,17 +35,30 @@ function toApiEvento(evento) {
   };
 }
 
-function fromApiEvento(payload) {
+function fromApiEvento(payload, { defaultNull = false } = {}) {
+  function normalize(value) {
+    if (value === undefined) {
+      return defaultNull ? null : undefined;
+    }
+
+    return value;
+  }
+
   return {
     data: payload.date,
     titulo: payload.title,
-    descricao: payload.description ?? null,
-    cor: payload.color ?? null,
-    cliente_id: payload.clientId ?? null,
+    descricao: normalize(payload.description),
+    cor: normalize(payload.color),
+    cliente_id: normalize(payload.clientId),
   };
 }
 
 function handleError(res, error) {
+  if (error instanceof ZodError) {
+    const message = error.issues?.[0]?.message || 'Dados inválidos.';
+    return res.status(400).json({ error: message });
+  }
+
   if (error?.code === 'NOT_IMPLEMENTED') {
     return res.status(501).json({ error: error.message });
   }
@@ -46,56 +74,256 @@ function handleError(res, error) {
   return res.status(500).json({ error: error?.message || 'Erro interno do servidor.' });
 }
 
+const normalizeNullableStringSchema = z
+  .union([z.string(), z.number(), z.literal(null)])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    const normalized = String(value).trim();
+    return normalized.length === 0 ? null : normalized;
+  });
+
+const optionalEmailSchema = z
+  .union([z.string(), z.literal(null)])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    const normalized = value.trim();
+    return normalized.length === 0 ? null : normalized;
+  })
+  .refine(
+    (value) =>
+      value === undefined ||
+      value === null ||
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+    {
+      message: 'Campo "email" deve ser um email válido.',
+    }
+  );
+
+const clienteCreateSchema = z.object({
+  nome: z
+    .string({ required_error: 'Campo "nome" é obrigatório.' })
+    .trim()
+    .min(1, 'Campo "nome" é obrigatório.'),
+  telefone: normalizeNullableStringSchema,
+  email: optionalEmailSchema,
+});
+
+const clienteUpdateSchema = clienteCreateSchema
+  .partial()
+  .refine((value) => value.nome || value.telefone !== undefined || value.email !== undefined, {
+    message: 'Informe ao menos um campo para atualizar.',
+  });
+
+const clientesQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === undefined || value.length === 0 ? undefined : value)),
+  page: z.coerce.number().int().min(1).optional(),
+});
+
+const optionalDateParamSchema = z
+  .string()
+  .trim()
+  .refine((value) => /^\d{4}-\d{2}-\d{2}$/.test(value), {
+    message: 'Datas devem estar no formato YYYY-MM-DD.',
+  });
+
+const eventosQuerySchema = z
+  .object({
+    from: optionalDateParamSchema.optional(),
+    to: optionalDateParamSchema.optional(),
+  })
+  .refine((value) => {
+    if (value.from && value.to) {
+      return value.from <= value.to;
+    }
+
+    return true;
+  }, {
+    message: 'O parâmetro "from" deve ser menor ou igual a "to".',
+  });
+
+const clientIdSchema = z
+  .union([
+    z
+      .number()
+      .int()
+      .positive({ message: 'Campo "clientId" deve ser um número inteiro positivo.' }),
+    z
+      .string()
+      .trim()
+      .regex(/^\d+$/, { message: 'Campo "clientId" deve ser um número inteiro positivo.' })
+      .transform((value) => Number(value)),
+    z.literal(null),
+  ])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    return Number(value);
+  });
+
+const eventoCreateSchema = z.object({
+  date: z
+    .string({ required_error: 'Campo "date" é obrigatório.' })
+    .trim()
+    .min(1, 'Campo "date" é obrigatório.')
+    .refine((value) => !Number.isNaN(Date.parse(value)), {
+      message: 'Campo "date" deve ser uma data válida.',
+    }),
+  title: z
+    .string({ required_error: 'Campo "title" é obrigatório.' })
+    .trim()
+    .min(1, 'Campo "title" é obrigatório.'),
+  description: normalizeNullableStringSchema,
+  color: normalizeNullableStringSchema,
+  clientId: clientIdSchema,
+});
+
+const eventoUpdateSchema = eventoCreateSchema
+  .partial()
+  .refine(
+    (value) =>
+      value.date !== undefined ||
+      value.title !== undefined ||
+      value.description !== undefined ||
+      value.color !== undefined ||
+      value.clientId !== undefined,
+    { message: 'Informe ao menos um campo para atualizar.' }
+  );
+
+const CLIENTES_PAGE_SIZE = 10;
+
+function extractValidationError(error) {
+  if (error instanceof ZodError) {
+    return error.issues?.[0]?.message || 'Dados inválidos.';
+  }
+
+  return 'Dados inválidos.';
+}
+
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok', storage: STORAGE });
 });
 
-app.get('/api/clients', async (req, res) => {
+app.get('/api/clientes', async (req, res) => {
   try {
-    const clientes = await Promise.resolve(storage.listClientes());
-    res.json({ clients: clientes });
-  } catch (error) {
-    handleError(res, error);
-  }
-});
-
-app.post('/api/clients', async (req, res) => {
-  try {
-    const { nome, telefone = null, email = null } = req.body || {};
-
-    if (!nome) {
-      return res.status(400).json({ error: 'Campo "nome" é obrigatório.' });
+    const parsedQuery = clientesQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({ error: extractValidationError(parsedQuery.error) });
     }
 
-    const cliente = await Promise.resolve(
-      storage.createCliente({ nome, telefone, email })
-    );
+    const { q, page: rawPage } = parsedQuery.data;
+    const page = rawPage ?? 1;
 
-    res.status(201).json({ client: cliente });
+    const clientes = await Promise.resolve(storage.listClientes());
+    const filteredClientes =
+      q === undefined
+        ? clientes
+        : clientes.filter((cliente) => {
+            const normalizedQuery = q.toLowerCase();
+            return ['nome', 'email', 'telefone'].some((field) => {
+              const value = cliente[field];
+              if (value === undefined || value === null) {
+                return false;
+              }
+
+              return String(value).toLowerCase().includes(normalizedQuery);
+            });
+          });
+
+    const total = filteredClientes.length;
+    const totalPages = total === 0 ? 0 : Math.ceil(total / CLIENTES_PAGE_SIZE);
+    const start = (page - 1) * CLIENTES_PAGE_SIZE;
+    const end = start + CLIENTES_PAGE_SIZE;
+    const paginatedClientes = filteredClientes.slice(start, end);
+
+    res.json({
+      clientes: paginatedClientes,
+      page,
+      pageSize: CLIENTES_PAGE_SIZE,
+      total,
+      totalPages,
+    });
   } catch (error) {
     handleError(res, error);
   }
 });
 
-app.put('/api/clients/:id', async (req, res) => {
+app.post('/api/clientes', async (req, res) => {
+  try {
+    const parsedBody = clienteCreateSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({ error: extractValidationError(parsedBody.error) });
+    }
+
+    const { nome, telefone, email } = parsedBody.data;
+    const cliente = await Promise.resolve(
+      storage.createCliente({
+        nome,
+        telefone: telefone ?? null,
+        email: email ?? null,
+      })
+    );
+
+    res.status(201).json({ cliente });
+  } catch (error) {
+    handleError(res, error);
+  }
+});
+
+app.put('/api/clientes/:id', async (req, res) => {
   try {
     const { id } = req.params;
-    const { nome, telefone, email } = req.body || {};
+    const parsedBody = clienteUpdateSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({ error: extractValidationError(parsedBody.error) });
+    }
+
+    const { nome, telefone, email } = parsedBody.data;
     const updated = await Promise.resolve(
-      storage.updateCliente(id, { nome, telefone, email })
+      storage.updateCliente(id, {
+        nome,
+        telefone: telefone === undefined ? undefined : telefone,
+        email: email === undefined ? undefined : email,
+      })
     );
 
     if (!updated) {
       return res.status(404).json({ error: 'Cliente não encontrado.' });
     }
 
-    res.json({ client: updated });
+    res.json({ cliente: updated });
   } catch (error) {
     handleError(res, error);
   }
 });
 
-app.delete('/api/clients/:id', async (req, res) => {
+app.delete('/api/clientes/:id', async (req, res) => {
   try {
     const { id } = req.params;
     const removed = await Promise.resolve(storage.deleteCliente(id));
@@ -110,48 +338,84 @@ app.delete('/api/clients/:id', async (req, res) => {
   }
 });
 
-app.get('/api/events', async (req, res) => {
+app.get('/api/eventos', async (req, res) => {
   try {
+    const parsedQuery = eventosQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({ error: extractValidationError(parsedQuery.error) });
+    }
+
+    const { from, to } = parsedQuery.data;
+    const fromDate = from ? new Date(`${from}T00:00:00.000Z`) : null;
+    const toDate = to ? new Date(`${to}T23:59:59.999Z`) : null;
+
     const eventos = await Promise.resolve(storage.listEventos());
-    res.json({ events: eventos.map(toApiEvento) });
+    const filteredEventos = eventos.filter((evento) => {
+      if (!fromDate && !toDate) {
+        return true;
+      }
+
+      const eventoDate = new Date(evento.data);
+      if (Number.isNaN(eventoDate.getTime())) {
+        return false;
+      }
+
+      if (fromDate && eventoDate < fromDate) {
+        return false;
+      }
+
+      if (toDate && eventoDate > toDate) {
+        return false;
+      }
+
+      return true;
+    });
+
+    res.json({ eventos: filteredEventos.map(toApiEvento) });
   } catch (error) {
     handleError(res, error);
   }
 });
 
-app.post('/api/events', async (req, res) => {
-  const { date, title, description = null, color = null, clientId = null } =
-    req.body || {};
-
-  if (!date || !title) {
-    return res
-      .status(400)
-      .json({ error: 'Campos "date" e "title" são obrigatórios.' });
-  }
-
+app.post('/api/eventos', async (req, res) => {
   try {
+    const parsedBody = eventoCreateSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({ error: extractValidationError(parsedBody.error) });
+    }
+
+    const { date, title, description, color, clientId } = parsedBody.data;
     const created = await Promise.resolve(
       storage.createEvento(
-        fromApiEvento({ date, title, description, color, clientId })
+        fromApiEvento(
+          {
+            date,
+            title,
+            description: description ?? null,
+            color: color ?? null,
+            clientId: clientId ?? null,
+          },
+          { defaultNull: true }
+        )
       )
     );
 
-    res.status(201).json({ event: toApiEvento(created) });
+    res.status(201).json({ evento: toApiEvento(created) });
   } catch (error) {
     handleError(res, error);
   }
 });
 
-app.put('/api/events/:id', async (req, res) => {
+app.put('/api/eventos/:id', async (req, res) => {
   const { id } = req.params;
-  const { date, title, description = null, color = null, clientId = null } =
-    req.body || {};
-
-  if (!id) {
-    return res.status(400).json({ error: 'O identificador do evento é obrigatório.' });
-  }
 
   try {
+    const parsedBody = eventoUpdateSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({ error: extractValidationError(parsedBody.error) });
+    }
+
+    const { date, title, description, color, clientId } = parsedBody.data;
     const updated = await Promise.resolve(
       storage.updateEvento(
         id,
@@ -163,13 +427,13 @@ app.put('/api/events/:id', async (req, res) => {
       return res.status(404).json({ error: 'Evento não encontrado.' });
     }
 
-    res.json({ event: toApiEvento(updated) });
+    res.json({ evento: toApiEvento(updated) });
   } catch (error) {
     handleError(res, error);
   }
 });
 
-app.delete('/api/events/:id', async (req, res) => {
+app.delete('/api/eventos/:id', async (req, res) => {
   const { id } = req.params;
   if (!id) {
     return res.status(400).json({ error: 'O identificador do evento é obrigatório.' });


### PR DESCRIPTION
## Summary
- adiciona validação com Zod, paginação e busca às rotas de clientes
- cria filtro por intervalo de datas para eventos e padroniza respostas de erro
- libera CORS para http://localhost:* e documenta os endpoints com exemplos de curl

## Testing
- node --check backend/server.js

------
https://chatgpt.com/codex/tasks/task_e_68dfad1115dc8333bfc668692d9a5f7d