### PR TITLE
Add seed script to populate sample CRM data

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "seed": "node src/scripts/seed.js"
   },
   "dependencies": {
     "better-sqlite3": "^9.4.0",

--- a/backend/src/scripts/seed.js
+++ b/backend/src/scripts/seed.js
@@ -1,0 +1,91 @@
+const storage = require('../storage');
+
+function seedClientes() {
+  const existingClientes = storage.listClientes();
+  if (existingClientes.length > 0) {
+    console.log('Clientes já existem na base, nenhum cliente criado.');
+    return existingClientes;
+  }
+
+  const clientesData = [
+    {
+      nome: 'Acme Corp',
+      telefone: '+55 11 4000-1234',
+      email: 'contato@acmecorp.com',
+    },
+    {
+      nome: 'Beta Solutions',
+      telefone: '+55 21 3555-9876',
+      email: 'suporte@betasolutions.com',
+    },
+    {
+      nome: 'Gamma Tech',
+      telefone: '+55 31 3222-4567',
+      email: 'vendas@gammatech.com',
+    },
+  ];
+
+  const createdClientes = clientesData.map((cliente) => storage.createCliente(cliente));
+  console.log(`Criados ${createdClientes.length} clientes.`);
+  return createdClientes;
+}
+
+function seedEventos(clientes) {
+  const existingEventos = storage.listEventos();
+  if (existingEventos.length > 0) {
+    console.log('Eventos já existem na base, nenhum evento criado.');
+    return existingEventos;
+  }
+
+  const clientesByName = new Map(clientes.map((cliente) => [cliente.nome, cliente]));
+
+  const eventosData = [
+    {
+      data: '2024-05-10',
+      titulo: 'Reunião de Alinhamento',
+      descricao: 'Apresentação das metas do trimestre com a equipe da Acme Corp.',
+      cor: '#FF5733',
+      clienteNome: 'Acme Corp',
+    },
+    {
+      data: '2024-05-18',
+      titulo: 'Treinamento de Onboarding',
+      descricao: 'Sessão inicial com novos usuários da Beta Solutions.',
+      cor: '#33C1FF',
+      clienteNome: 'Beta Solutions',
+    },
+    {
+      data: '2024-06-02',
+      titulo: 'Revisão de Contrato',
+      descricao: 'Discussão sobre renovação contratual com a Gamma Tech.',
+      cor: '#8E44AD',
+      clienteNome: 'Gamma Tech',
+    },
+  ];
+
+  const createdEventos = eventosData.map(({ clienteNome, ...evento }) => {
+    const cliente = clientesByName.get(clienteNome);
+    return storage.createEvento({
+      ...evento,
+      cliente_id: cliente ? cliente.id : null,
+    });
+  });
+
+  console.log(`Criados ${createdEventos.length} eventos.`);
+  return createdEventos;
+}
+
+function main() {
+  try {
+    const clientes = seedClientes();
+    const allClientes = clientes.length ? clientes : storage.listClientes();
+    seedEventos(allClientes);
+    console.log('Seed concluído com sucesso.');
+    process.exit(0);
+  } catch (error) {
+    console.error('Erro ao executar seed:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a database seed script that populates sample clients and events only when the tables are empty
- ensure sample event dates use ISO YYYY-MM-DD formatting
- add an npm script to run the seed process easily

## Testing
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68dfd89c8f788333a3f940e7b9a148f8