### PR TITLE
Fix Live Server configuration and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,19 @@ backend/
 
 ## Frontend
 
-Para visualizar a interface basta servir a pasta `frontend` em um servidor estático (por exemplo, com a extensão "Live Server" do VS Code) ou abrir `frontend/index.html` diretamente no navegador.
+Para visualizar a interface basta servir os arquivos estáticos (por exemplo, com a extensão "Live Server" do VS Code) ou abrir `index.html` diretamente no navegador.
+
+> **Importante:** execute o backend antes de abrir o Live Server. Sem a API em execução as requisições retornarão erro de conexão.
+
+### Configuração do frontend
+
+O arquivo `env.front` define a URL base utilizada nas chamadas à API. Para ambientes locais o valor padrão é `http://localhost:4000`:
+
+```
+API_BASE_URL=http://localhost:4000
+```
+
+Você pode ajustar esse valor se expuser a API em outra porta/host. O frontend aceita as chaves `API_BASE_URL`, `VITE_API_BASE_URL`, `REACT_APP_API_BASE_URL` e `API_URL` para compatibilidade com diferentes setups.
 
 ### Novidades
 

--- a/env.front
+++ b/env.front
@@ -1,1 +1,1 @@
-API_URL=http://localhost:4000
+API_BASE_URL=http://localhost:4000

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,7 +1,12 @@
 (function () {
   const DEFAULT_BASE_URL = 'http://localhost:4000';
   const ENV_FILE_PATH = './env.front';
-  const ENV_KEYS = ['VITE_API_BASE_URL', 'API_BASE_URL', 'REACT_APP_API_BASE_URL'];
+  const ENV_KEYS = [
+    'VITE_API_BASE_URL',
+    'API_BASE_URL',
+    'REACT_APP_API_BASE_URL',
+    'API_URL',
+  ];
 
   let apiBaseUrl = DEFAULT_BASE_URL;
   let envLoaded = false;


### PR DESCRIPTION
## Summary
- allow the frontend to resolve API URLs configured with API_URL in env.front
- normalize the default frontend configuration to use API_BASE_URL
- document the required backend startup and API URL configuration for Live Server usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cdacafe88333bf73be32f1e80a4c