### PR TITLE
Fix SQLite compras table initialization order

### DIFF
--- a/backend/src/storage/sqlite.js
+++ b/backend/src/storage/sqlite.js
@@ -36,6 +36,33 @@ db.exec(`
   );
 `);
 
+db.exec(`
+  CREATE TABLE IF NOT EXISTS compras (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cliente_id INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    armacao TEXT,
+    material_armacao TEXT,
+    valor_armacao REAL,
+    lente TEXT,
+    valor_lente REAL,
+    nota_fiscal TEXT,
+    oe_esferico TEXT,
+    oe_cilindrico TEXT,
+    oe_eixo TEXT,
+    oe_dnp TEXT,
+    oe_adicao TEXT,
+    od_esferico TEXT,
+    od_cilindrico TEXT,
+    od_eixo TEXT,
+    od_dnp TEXT,
+    od_adicao TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (cliente_id) REFERENCES clientes(id) ON DELETE CASCADE
+  );
+`);
+
 function ensureColumn(table, column, definition) {
   const info = db.pragma(`table_info(${table})`);
   const hasColumn = info.some((entry) => entry.name === column);
@@ -80,33 +107,6 @@ const purchaseColumns = [
 purchaseColumns.forEach(([column, definition]) => {
   ensureColumn('compras', column, definition);
 });
-
-db.exec(`
-  CREATE TABLE IF NOT EXISTS compras (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    cliente_id INTEGER NOT NULL,
-    data TEXT NOT NULL,
-    armacao TEXT,
-    material_armacao TEXT,
-    valor_armacao REAL,
-    lente TEXT,
-    valor_lente REAL,
-    nota_fiscal TEXT,
-    oe_esferico TEXT,
-    oe_cilindrico TEXT,
-    oe_eixo TEXT,
-    oe_dnp TEXT,
-    oe_adicao TEXT,
-    od_esferico TEXT,
-    od_cilindrico TEXT,
-    od_eixo TEXT,
-    od_dnp TEXT,
-    od_adicao TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    FOREIGN KEY (cliente_id) REFERENCES clientes(id) ON DELETE CASCADE
-  );
-`);
 
 const listClientesStmt = db.prepare(`
   SELECT


### PR DESCRIPTION
## Summary
- create the compras table before ensuring its columns so migrations succeed

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e425b78ce483338e211b575860d8fa