### PR TITLE
Automate post-sale contact scheduling and UI updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,7 +624,9 @@
                 <header class="client-card__header">
                   <h2 class="client-card__title">Histórico de contato</h2>
                 </header>
-                <div class="client-card__empty">Nenhum contato registrado.</div>
+                <div class="client-contact-history" data-role="client-contact-history">
+                  <div class="client-card__empty">Nenhum contato registrado.</div>
+                </div>
               </article>
             </div>
           </div>
@@ -667,15 +669,6 @@
                 <label class="client-form__field">
                   <span class="client-form__label">Data de nascimento</span>
                   <input type="date" name="birthDate" required />
-                </label>
-                <label class="client-form__field">
-                  <span class="client-form__label">Estado do cliente</span>
-                  <select name="state" required>
-                    <option value="">Selecione</option>
-                    <option value="pos-venda">Pós-venda</option>
-                    <option value="oferta">Oferta</option>
-                    <option value="nao-contatar">Não contatar</option>
-                  </select>
                 </label>
                 <label class="client-form__field client-form__field--checkbox">
                   <input type="checkbox" name="acceptsContact" />
@@ -1148,6 +1141,15 @@
             aria-label="Excluir evento"
           >
             🗑
+          </button>
+          <button
+            class="modal__action modal__action--contact"
+            type="button"
+            data-action="toggle-contact"
+            aria-label="Alternar status do contato"
+            hidden
+          >
+            ✔
           </button>
         </div>
       </div>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -345,13 +345,6 @@
       result.userType = normalizedUserType ? normalizedUserType.toUpperCase() : normalizedUserType;
     }
 
-    const stateValue =
-      payload.state !== undefined ? payload.state : payload.estadoCliente ?? payload['estado_cliente'];
-    if (stateValue !== undefined) {
-      const normalizedState = normalizeNullable(stateValue);
-      result.state = normalizedState ? normalizedState.toLowerCase() : normalizedState;
-    }
-
     if (Array.isArray(payload.interests)) {
       const normalizedInterests = payload.interests
         .map((item) => normalizeNullable(item))
@@ -432,6 +425,14 @@
       const body = JSON.stringify(normalizeClientPayload(payload));
       return request(`/api/clientes/${encodeURIComponent(id)}`, {
         method: 'PUT',
+        body,
+      });
+    },
+    async updateContact(id, payload) {
+      const completedValue = payload?.completed;
+      const body = JSON.stringify({ completed: Boolean(completedValue) });
+      return request(`/api/contatos/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
         body,
       });
     },

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -72,6 +72,13 @@ function normalizeEventData(rawEvent) {
     description: rawEvent.description ?? rawEvent.descricao ?? '',
     color: rawEvent.color ?? rawEvent.cor ?? '',
     clientId: rawEvent.clientId ?? rawEvent.cliente_id ?? null,
+    type: rawEvent.type ?? rawEvent.eventType ?? (String(rawEvent.id ?? '').startsWith('contact-') ? 'contact' : 'event'),
+    contactId: rawEvent.contactId ?? rawEvent.contatoId ?? rawEvent.contato_id ?? null,
+    contactCompleted: Boolean(rawEvent.contactCompleted ?? rawEvent.completed ?? rawEvent.efetuado),
+    contactMonths:
+      rawEvent.contactMonths ?? rawEvent.monthsOffset ?? rawEvent.prazoMeses ?? rawEvent.prazo_meses ?? null,
+    purchaseId: rawEvent.purchaseId ?? rawEvent.compraId ?? rawEvent.compra_id ?? null,
+    purchaseDate: rawEvent.purchaseDate ?? rawEvent.dataCompra ?? rawEvent.data_compra ?? null,
   };
 }
 
@@ -246,6 +253,13 @@ function renderEventsForCell(cell, dateKey) {
     chip.type = 'button';
     chip.textContent = event.title;
     chip.dataset.eventId = String(event.id);
+    chip.dataset.eventType = event.type || 'event';
+    if (event.type === 'contact') {
+      chip.classList.add('calendar__event-chip--contact');
+      if (event.contactCompleted) {
+        chip.classList.add('is-completed');
+      }
+    }
     chip.addEventListener('click', () => openEventDetailsModal(event));
     eventsContainer.appendChild(chip);
   });

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -20,6 +20,7 @@ const eventDetailsBody = eventDetailsOverlay?.querySelector('[data-details="body
 const eventDetailsCloseButton = eventDetailsOverlay?.querySelector('[data-action="close"]');
 const eventDetailsEditButton = eventDetailsOverlay?.querySelector('[data-action="edit"]');
 const eventDetailsDeleteButton = eventDetailsOverlay?.querySelector('[data-action="delete"]');
+const eventDetailsToggleContactButton = eventDetailsOverlay?.querySelector('[data-action="toggle-contact"]');
 const eventDetailsModal = eventDetailsOverlay?.querySelector('.modal');
 const userSelectorButton = document.querySelector('[data-role="user-selector"]');
 const userSelectorOverlay = document.querySelector('[data-modal="user-selector"]');
@@ -35,6 +36,7 @@ const clientDetailDeleteButton = document.querySelector('[data-role="client-deta
 const clientDetailElement = document.querySelector('[data-role="client-detail"]');
 const clientDetailFields = clientDetailElement?.querySelectorAll('[data-client-field]');
 const clientPurchasesContainer = clientDetailElement?.querySelector('[data-role="client-purchases"]');
+const clientContactHistoryContainer = clientDetailElement?.querySelector('[data-role="client-contact-history"]');
 const clientInterestsContainer = clientDetailElement?.querySelector('[data-role="client-interests"]');
 const clientInterestsEditButton = document.querySelector('[data-role="client-interests-edit"]');
 const clientFormElement = document.querySelector('#client-registration-form');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -99,6 +99,10 @@ eventDetailsDeleteButton?.addEventListener('click', () => {
   handleDeleteCurrentEvent();
 });
 
+eventDetailsToggleContactButton?.addEventListener('click', () => {
+  handleToggleContactFromModal();
+});
+
 eventDetailsModal?.addEventListener('mouseenter', () => {
   isDetailHovered = true;
   clearDetailAutoClose();

--- a/styles.css
+++ b/styles.css
@@ -822,6 +822,16 @@ body.modal-open {
   text-align: center;
 }
 
+.calendar__event-chip--contact {
+  background-color: #22c55e;
+  color: #052e16;
+}
+
+.calendar__event-chip--contact.is-completed {
+  background-color: #14532d;
+  color: #ecfdf5;
+}
+
 .calendar__event-chip:hover,
 .calendar__event-chip:focus {
   transform: translateY(-2px);
@@ -1152,6 +1162,10 @@ body.modal-open {
 
 .modal__action--delete {
   color: #ff5252;
+}
+
+.modal__action--contact {
+  color: #22c55e;
 }
 
 .calendar__date--empty {
@@ -1960,6 +1974,107 @@ body.modal-open {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.client-contact-history {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.client-contact {
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  border-radius: 14px;
+  overflow: hidden;
+  background-color: rgba(34, 197, 94, 0.08);
+}
+
+.client-contact__toggle {
+  width: 100%;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.client-contact__toggle:hover,
+.client-contact__toggle:focus {
+  background-color: rgba(34, 197, 94, 0.12);
+  outline: none;
+}
+
+.client-contact__details {
+  padding: 0 18px 18px;
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.client-contact.is-open .client-contact__details {
+  display: flex;
+}
+
+.client-contact__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.client-contact__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background-color: rgba(15, 118, 110, 0.15);
+}
+
+.client-contact__label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 14px;
+}
+
+.client-contact__label span:last-child {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 13px;
+}
+
+.client-contact__status {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+}
+
+.client-contact__status:hover,
+.client-contact__status:focus {
+  background-color: rgba(34, 197, 94, 0.35);
+  outline: none;
+}
+
+.client-contact__status.is-completed {
+  background-color: #15803d;
+  color: #ecfdf5;
+}
+
+.client-contact__status:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .client-purchase {


### PR DESCRIPTION
## Summary
- generate scheduled contact records for each purchase and auto-sync client states
- expose contact updates through the API and surface contact reminders alongside calendar events
- refresh the client detail UI with expandable contact history chips and styling for the new workflow

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51e98949c833382d508f141891301