### PR TITLE
Revamp calendar contact status handling

### DIFF
--- a/backend/src/storage/sheets.js
+++ b/backend/src/storage/sheets.js
@@ -385,6 +385,7 @@ function createEvento({
   descricao = null,
   cor = null,
   cliente_id = null,
+  completed = false,
 }) {
   if (!data || !titulo) {
     throw new Error('Campos "data" e "titulo" são obrigatórios.');
@@ -398,6 +399,7 @@ function createEvento({
     descricao,
     cor,
     cliente_id,
+    completed: Boolean(completed),
     created_at: timestamp,
     updated_at: timestamp,
   };
@@ -406,7 +408,7 @@ function createEvento({
   return { ...evento };
 }
 
-function updateEvento(id, { data, titulo, descricao, cor, cliente_id }) {
+function updateEvento(id, { data, titulo, descricao, cor, cliente_id, completed }) {
   const eventoId = Number(id);
   if (Number.isNaN(eventoId)) {
     return null;
@@ -422,6 +424,9 @@ function updateEvento(id, { data, titulo, descricao, cor, cliente_id }) {
   evento.descricao = descricao ?? evento.descricao;
   evento.cor = cor ?? evento.cor;
   evento.cliente_id = cliente_id === undefined ? evento.cliente_id : cliente_id;
+  if (completed !== undefined) {
+    evento.completed = Boolean(completed);
+  }
   evento.updated_at = new Date().toISOString();
 
   return { ...evento };

--- a/index.html
+++ b/index.html
@@ -1112,7 +1112,16 @@
         aria-labelledby="event-details-title"
       >
         <div class="modal__header">
-          <h2 class="modal__title" id="event-details-title">Detalhes do evento</h2>
+          <h2 class="modal__title" id="event-details-title">
+            <span data-details="title-entity">Detalhes do evento</span>
+            <span class="modal__title-separator" aria-hidden="true">-</span>
+            <span
+              class="modal__title-status modal__title-status--pending"
+              data-details="status-label"
+            >
+              Pendente
+            </span>
+          </h2>
           <button
             class="modal__close"
             type="button"
@@ -1127,29 +1136,12 @@
         </div>
         <div class="modal__actions">
           <button
-            class="modal__action modal__action--edit"
+            class="modal__status-button"
             type="button"
-            data-action="edit"
-            aria-label="Editar evento"
-          >
-            ✎
-          </button>
-          <button
-            class="modal__action modal__action--delete"
-            type="button"
-            data-action="delete"
-            aria-label="Excluir evento"
-          >
-            🗑
-          </button>
-          <button
-            class="modal__action modal__action--contact"
-            type="button"
-            data-action="toggle-contact"
-            aria-label="Alternar status do contato"
+            data-action="toggle-status"
             hidden
           >
-            ✔
+            Marcar como Efetuado
           </button>
         </div>
       </div>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -228,13 +228,17 @@
     if (!payload) {
       return null;
     }
-    return {
+    const result = {
       date: payload.date,
       title: payload.title,
       description: payload.description ?? null,
       color: payload.color ?? null,
       clientId: payload.clientId ?? null,
     };
+    if (payload.completed !== undefined) {
+      result.completed = Boolean(payload.completed);
+    }
+    return result;
   }
 
   function normalizeClientPayload(payload) {

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -18,9 +18,9 @@ const addEventSaveButton = addEventOverlay?.querySelector('[data-action="save"]'
 const eventDetailsOverlay = document.querySelector('[data-modal="event-details"]');
 const eventDetailsBody = eventDetailsOverlay?.querySelector('[data-details="body"]');
 const eventDetailsCloseButton = eventDetailsOverlay?.querySelector('[data-action="close"]');
-const eventDetailsEditButton = eventDetailsOverlay?.querySelector('[data-action="edit"]');
-const eventDetailsDeleteButton = eventDetailsOverlay?.querySelector('[data-action="delete"]');
-const eventDetailsToggleContactButton = eventDetailsOverlay?.querySelector('[data-action="toggle-contact"]');
+const eventDetailsTitleEntity = eventDetailsOverlay?.querySelector('[data-details="title-entity"]');
+const eventDetailsTitleStatus = eventDetailsOverlay?.querySelector('[data-details="status-label"]');
+const eventDetailsToggleStatusButton = eventDetailsOverlay?.querySelector('[data-action="toggle-status"]');
 const eventDetailsModal = eventDetailsOverlay?.querySelector('.modal');
 const userSelectorButton = document.querySelector('[data-role="user-selector"]');
 const userSelectorOverlay = document.querySelector('[data-modal="user-selector"]');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -16,7 +16,21 @@ homeShortcuts.forEach((shortcut) => {
 
 initializeUserSelector();
 
-setActivePage('home');
+const initialPage =
+  typeof getStoredActivePage === 'function' ? getStoredActivePage() : null;
+
+const hasStoredPage = initialPage
+  && (
+    Array.from(sidebarButtons).some((button) => button.dataset.page === initialPage)
+    || Array.from(menus).some((menu) => menu.dataset.page === initialPage)
+    || Array.from(contentPages).some((section) => section.dataset.page === initialPage)
+  );
+
+if (hasStoredPage) {
+  setActivePage(initialPage);
+} else {
+  setActivePage('home');
+}
 
 if (prevMonthButton && nextMonthButton) {
   prevMonthButton.addEventListener('click', () => changeCalendarPeriod(-1));
@@ -86,31 +100,8 @@ eventDetailsCloseButton?.addEventListener('click', () => {
   closeEventDetailsModal();
 });
 
-eventDetailsEditButton?.addEventListener('click', () => {
-  if (!currentDetailEvent) {
-    return;
-  }
-  const eventToEdit = currentDetailEvent;
-  closeEventDetailsModal();
-  openAddEventModal(eventToEdit);
-});
-
-eventDetailsDeleteButton?.addEventListener('click', () => {
-  handleDeleteCurrentEvent();
-});
-
-eventDetailsToggleContactButton?.addEventListener('click', () => {
-  handleToggleContactFromModal();
-});
-
-eventDetailsModal?.addEventListener('mouseenter', () => {
-  isDetailHovered = true;
-  clearDetailAutoClose();
-});
-
-eventDetailsModal?.addEventListener('mouseleave', () => {
-  isDetailHovered = false;
-  scheduleDetailAutoClose(3000);
+eventDetailsToggleStatusButton?.addEventListener('click', () => {
+  handleToggleStatusFromModal();
 });
 
 document.addEventListener('keydown', (event) => {

--- a/scripts/modals.js
+++ b/scripts/modals.js
@@ -65,7 +65,6 @@ function closeAddEventModal() {
   editingEventOriginalDateKey = null;
 }
 let isSavingEvent = false;
-let isDeletingEvent = false;
 
 async function handleSaveEvent() {
   if (!addEventForm) {
@@ -134,37 +133,27 @@ async function handleSaveEvent() {
   }
 }
 
-function clearDetailAutoClose() {
-  if (detailAutoCloseTimeout) {
-    clearTimeout(detailAutoCloseTimeout);
-    detailAutoCloseTimeout = null;
-  }
-}
-
-function scheduleDetailAutoClose(delay) {
-  clearDetailAutoClose();
-  detailAutoCloseTimeout = setTimeout(() => {
-    if (!isDetailHovered) {
-      closeEventDetailsModal();
-    }
-  }, delay);
-}
-
 function closeEventDetailsModal() {
   closeOverlay(eventDetailsOverlay);
-  clearDetailAutoClose();
-  if (eventDetailsToggleContactButton) {
-    eventDetailsToggleContactButton.hidden = true;
-    eventDetailsToggleContactButton.disabled = false;
-    eventDetailsToggleContactButton.dataset.contactId = '';
-    eventDetailsToggleContactButton.dataset.completed = 'false';
+  if (eventDetailsToggleStatusButton) {
+    eventDetailsToggleStatusButton.hidden = true;
+    eventDetailsToggleStatusButton.disabled = false;
+    eventDetailsToggleStatusButton.dataset.contactId = '';
+    eventDetailsToggleStatusButton.dataset.eventId = '';
+    eventDetailsToggleStatusButton.dataset.entityType = '';
+    eventDetailsToggleStatusButton.dataset.statusKey = '';
   }
   currentDetailEvent = null;
 }
 
-function createDetailsRow(value, isEmpty = false) {
+function createDetailsRow(label, value, { isEmpty = false } = {}) {
   const container = document.createElement('div');
   container.className = 'modal__details-row';
+
+  const labelElement = document.createElement('span');
+  labelElement.className = 'modal__details-label';
+  labelElement.textContent = `${label}:`;
+  container.appendChild(labelElement);
 
   const valueElement = document.createElement('p');
   valueElement.className = 'modal__details-value';
@@ -178,64 +167,137 @@ function createDetailsRow(value, isEmpty = false) {
   return container;
 }
 
+function formatShortDate(dateKey) {
+  if (!dateKey) {
+    return '';
+  }
+  const normalized = String(dateKey).slice(0, 10);
+  const parts = normalized.split('-');
+  if (parts.length !== 3) {
+    return normalized;
+  }
+  const [year, month, day] = parts;
+  return `${day}/${month}/${year.slice(-2)}`;
+}
+
+function formatPhoneNumber(phone) {
+  if (!phone) {
+    return 'Não informado';
+  }
+  const digits = String(phone).replace(/\D/g, '');
+  if (digits.length === 11) {
+    return digits.replace(/(\d{2})(\d{5})(\d{4})/, '($1) $2-$3');
+  }
+  if (digits.length === 10) {
+    return digits.replace(/(\d{2})(\d{4})(\d{4})/, '($1) $2-$3');
+  }
+  if (digits.length === 0) {
+    return 'Não informado';
+  }
+  return String(phone);
+}
+
 function renderEventDetailsView() {
   if (!eventDetailsBody || !currentDetailEvent) {
     return;
   }
 
   const event = currentDetailEvent;
+  const status = typeof getEventStatus === 'function'
+    ? getEventStatus(event)
+    : { key: 'pending', label: 'Pendente' };
+
+  if (eventDetailsTitleEntity) {
+    eventDetailsTitleEntity.textContent =
+      event.type === 'contact' ? 'Detalhes do Contato' : 'Detalhes do Evento';
+  }
+
+  if (eventDetailsTitleStatus) {
+    eventDetailsTitleStatus.textContent = status.label;
+    eventDetailsTitleStatus.className = `modal__title-status modal__title-status--${status.key}`;
+  }
+
   eventDetailsBody.innerHTML = '';
 
-  const eventDate = event.date ? formatDisplayDate(event.date) : '';
-  if (eventDate) {
-    eventDetailsBody.appendChild(createDetailsRow(eventDate));
+  const scheduledDate = event.date ? formatShortDate(event.date) : '';
+  if (scheduledDate) {
+    const dateLabel = event.type === 'contact' ? 'Data do contato' : 'Data do evento';
+    eventDetailsBody.appendChild(createDetailsRow(dateLabel, scheduledDate));
   }
 
   if (event.type === 'contact') {
-    const title = event.title || 'Contato pós-venda';
-    eventDetailsBody.appendChild(createDetailsRow(title));
-    const statusText = event.contactCompleted ? 'Status: Contato efetuado' : 'Status: Contato pendente';
-    eventDetailsBody.appendChild(createDetailsRow(statusText));
-    const purchaseDate = event.purchaseDate ? String(event.purchaseDate).slice(0, 10) : '';
-    if (purchaseDate) {
+    const clientName = event.clientName || 'Cliente não informado';
+    eventDetailsBody.appendChild(createDetailsRow('Nome do cliente', `Nome: ${clientName}`));
+
+    const phone = formatPhoneNumber(event.clientPhone);
+    eventDetailsBody.appendChild(createDetailsRow('Telefone do cliente', `Telefone: ${phone}`));
+
+    const monthsLabel = typeof formatPostSaleLabel === 'function'
+      ? formatPostSaleLabel(event.contactMonths ?? event.monthsOffset)
+      : '';
+    const purchaseLabel = monthsLabel ? `Data da compra - (${monthsLabel})` : 'Data da compra';
+    const purchaseDate = event.purchaseDate ? formatShortDate(event.purchaseDate) : '';
+    const purchaseValue = purchaseDate
+      ? `Data da compra: ${purchaseDate}${monthsLabel ? ` - ${monthsLabel}` : ''}`
+      : 'Data da compra: Não informada';
+    eventDetailsBody.appendChild(
+      createDetailsRow(purchaseLabel, purchaseValue, { isEmpty: !purchaseDate })
+    );
+
+    const purchaseParts = [];
+    if (event.purchaseFrame) {
+      purchaseParts.push(`Armação: ${event.purchaseFrame}`);
+    }
+    if (event.purchaseLens) {
+      purchaseParts.push(`Lente: ${event.purchaseLens}`);
+    }
+    const purchaseText = purchaseParts.length
+      ? purchaseParts.join('  ')
+      : 'Informações não disponíveis';
+    eventDetailsBody.appendChild(
+      createDetailsRow('Compra do cliente', `Compra: ${purchaseText}`, {
+        isEmpty: !purchaseParts.length,
+      })
+    );
+  } else {
+    const title = event.title || 'Evento';
+    eventDetailsBody.appendChild(createDetailsRow('Título do evento', `Título: ${title}`));
+
+    if (event.clientName) {
       eventDetailsBody.appendChild(
-        createDetailsRow(`Compra em ${formatDisplayDate(purchaseDate)}`)
+        createDetailsRow('Cliente relacionado', `Cliente: ${event.clientName}`)
       );
     }
-  } else {
-    eventDetailsBody.appendChild(createDetailsRow(event.title));
-
-    if (event.description) {
-      eventDetailsBody.appendChild(createDetailsRow(event.description));
-    } else {
-      eventDetailsBody.appendChild(createDetailsRow('Nenhuma descrição informada.', true));
-    }
   }
 
-  if (eventDetailsEditButton) {
+  const observationSource =
+    event.notes ?? event.observacao ?? event.observation ?? event.description ?? '';
+  const hasObservation = Boolean(observationSource);
+  const observationText = hasObservation
+    ? String(observationSource)
+    : 'Sem observações registradas.';
+  eventDetailsBody.appendChild(
+    createDetailsRow('Observação', observationText, { isEmpty: !hasObservation })
+  );
+
+  if (eventDetailsToggleStatusButton) {
     const isContact = event.type === 'contact';
-    eventDetailsEditButton.hidden = isContact;
-    eventDetailsEditButton.disabled = isContact;
-  }
-
-  if (eventDetailsDeleteButton) {
-    const isContact = event.type === 'contact';
-    eventDetailsDeleteButton.hidden = isContact;
-    eventDetailsDeleteButton.disabled = isContact;
-  }
-
-  if (eventDetailsToggleContactButton) {
-    if (event.type === 'contact' && event.contactId) {
-      eventDetailsToggleContactButton.hidden = false;
-      eventDetailsToggleContactButton.dataset.contactId = String(event.contactId);
-      eventDetailsToggleContactButton.dataset.completed = event.contactCompleted ? 'true' : 'false';
-      eventDetailsToggleContactButton.textContent = event.contactCompleted
-        ? 'Marcar como pendente'
-        : 'Marcar como efetuado';
+    const hasIdentifier = isContact ? Boolean(event.contactId) : Boolean(event.id);
+    if (!hasIdentifier) {
+      eventDetailsToggleStatusButton.hidden = true;
+      eventDetailsToggleStatusButton.dataset.contactId = '';
+      eventDetailsToggleStatusButton.dataset.eventId = '';
+      eventDetailsToggleStatusButton.dataset.entityType = '';
+      eventDetailsToggleStatusButton.dataset.statusKey = status.key;
     } else {
-      eventDetailsToggleContactButton.hidden = true;
-      eventDetailsToggleContactButton.dataset.contactId = '';
-      eventDetailsToggleContactButton.dataset.completed = 'false';
+      eventDetailsToggleStatusButton.hidden = false;
+      eventDetailsToggleStatusButton.disabled = false;
+      eventDetailsToggleStatusButton.textContent =
+        status.key === 'completed' ? 'Marcar como Pendente' : 'Marcar como Efetuado';
+      eventDetailsToggleStatusButton.dataset.entityType = isContact ? 'contact' : 'event';
+      eventDetailsToggleStatusButton.dataset.contactId = isContact ? String(event.contactId) : '';
+      eventDetailsToggleStatusButton.dataset.eventId = String(event.id ?? '');
+      eventDetailsToggleStatusButton.dataset.statusKey = status.key;
     }
   }
 }
@@ -249,94 +311,77 @@ function openEventDetailsModal(event) {
   renderEventDetailsView();
 
   openOverlay(eventDetailsOverlay);
-  isDetailHovered = false;
-  scheduleDetailAutoClose(5000);
 }
 
-async function handleDeleteCurrentEvent() {
-  if (!currentDetailEvent || isDeletingEvent) {
+async function handleToggleStatusFromModal() {
+  if (!currentDetailEvent) {
     return;
   }
 
-  const errorMessage = 'Erro ao excluir o evento.';
+  const isContact = currentDetailEvent.type === 'contact';
+  if (isContact && !currentDetailEvent.contactId) {
+    return;
+  }
+  if (!isContact && !currentDetailEvent.id) {
+    return;
+  }
+
+  const currentlyCompleted = isContact
+    ? Boolean(currentDetailEvent.contactCompleted ?? currentDetailEvent.completed)
+    : Boolean(currentDetailEvent.completed);
+  const nextValue = !currentlyCompleted;
+
+  const successMessage = isContact
+    ? nextValue
+      ? 'Contato marcado como efetuado.'
+      : 'Contato marcado como pendente.'
+    : nextValue
+      ? 'Evento marcado como efetuado.'
+      : 'Evento marcado como pendente.';
+  const errorMessage = isContact ? 'Erro ao atualizar o contato.' : 'Erro ao atualizar o evento.';
 
   try {
-    isDeletingEvent = true;
-    if (eventDetailsDeleteButton) {
-      eventDetailsDeleteButton.disabled = true;
+    if (eventDetailsToggleStatusButton) {
+      eventDetailsToggleStatusButton.disabled = true;
     }
 
-    await window.api.deleteEvent(currentDetailEvent.id);
-
-    if (typeof window.showToast === 'function') {
-      window.showToast('Evento excluído com sucesso.', { type: 'success' });
-    }
-
-    closeEventDetailsModal();
-    await refreshCalendar({ showLoading: false });
-  } catch (error) {
-    const message = window.api?.getErrorMessage(error, errorMessage);
-    if (typeof window.showToast === 'function') {
-      window.showToast(message, { type: 'error' });
-    }
-  } finally {
-    if (eventDetailsDeleteButton) {
-      eventDetailsDeleteButton.disabled = false;
-    }
-    isDeletingEvent = false;
-  }
-}
-
-async function handleToggleContactFromModal() {
-  if (!currentDetailEvent || currentDetailEvent.type !== 'contact') {
-    return;
-  }
-
-  const contactId = currentDetailEvent.contactId;
-  if (!contactId) {
-    return;
-  }
-
-  const nextValue = !currentDetailEvent.contactCompleted;
-  const successMessage = nextValue
-    ? 'Contato marcado como efetuado.'
-    : 'Contato marcado como pendente.';
-  const errorMessage = 'Erro ao atualizar o contato.';
-
-  try {
-    if (eventDetailsToggleContactButton) {
-      eventDetailsToggleContactButton.disabled = true;
-    }
-
-    const response = await window.api.updateContact(contactId, { completed: nextValue });
-    if (response?.contato) {
-      const updatedContact = response.contato;
-      const completedValue =
-        updatedContact.completed ?? updatedContact.efetuado ?? updatedContact.realizado ?? nextValue;
-      currentDetailEvent.contactCompleted = Boolean(completedValue);
-      if (updatedContact.title) {
-        currentDetailEvent.title = updatedContact.title;
+    if (isContact) {
+      const response = await window.api.updateContact(currentDetailEvent.contactId, { completed: nextValue });
+      if (response?.contato) {
+        const updatedContact = response.contato;
+        const completedValue =
+          updatedContact.completed ?? updatedContact.efetuado ?? updatedContact.realizado ?? nextValue;
+        currentDetailEvent.contactCompleted = Boolean(completedValue);
+        currentDetailEvent.completed = currentDetailEvent.contactCompleted;
+        if (updatedContact.contactDate ?? updatedContact.data_contato) {
+          currentDetailEvent.date = String(updatedContact.contactDate ?? updatedContact.data_contato).slice(0, 10);
+        }
+        if (updatedContact.purchaseDate ?? updatedContact.data_compra) {
+          currentDetailEvent.purchaseDate = String(
+            updatedContact.purchaseDate ?? updatedContact.data_compra
+          ).slice(0, 10);
+        }
+      } else {
+        currentDetailEvent.contactCompleted = nextValue;
+        currentDetailEvent.completed = nextValue;
       }
-      if (updatedContact.contactDate ?? updatedContact.data_contato) {
-        currentDetailEvent.date = String(updatedContact.contactDate ?? updatedContact.data_contato).slice(0, 10);
-      }
-      if (updatedContact.purchaseDate ?? updatedContact.data_compra) {
-        currentDetailEvent.purchaseDate = String(
-          updatedContact.purchaseDate ?? updatedContact.data_compra
-        ).slice(0, 10);
+
+      if (typeof window.handleContactUpdateResponse === 'function' && response?.cliente) {
+        window.handleContactUpdateResponse(response.cliente);
       }
     } else {
-      currentDetailEvent.contactCompleted = nextValue;
-    }
-
-    if (typeof window.handleContactUpdateResponse === 'function' && response?.cliente) {
-      window.handleContactUpdateResponse(response.cliente);
+      await window.api.updateEvent(currentDetailEvent.id, { completed: nextValue });
+      currentDetailEvent.completed = nextValue;
     }
 
     renderEventDetailsView();
 
     if (typeof window.showToast === 'function') {
       window.showToast(successMessage, { type: 'success' });
+    }
+
+    if (!isContact && typeof window.refreshCalendar === 'function') {
+      window.refreshCalendar({ showLoading: false });
     }
   } catch (error) {
     const message = window.api?.getErrorMessage
@@ -346,8 +391,8 @@ async function handleToggleContactFromModal() {
       window.showToast(message, { type: 'error' });
     }
   } finally {
-    if (eventDetailsToggleContactButton) {
-      eventDetailsToggleContactButton.disabled = false;
+    if (eventDetailsToggleStatusButton) {
+      eventDetailsToggleStatusButton.disabled = false;
     }
   }
 }

--- a/scripts/navigation.js
+++ b/scripts/navigation.js
@@ -1,3 +1,26 @@
+const ACTIVE_PAGE_STORAGE_KEY = 'crm-active-page';
+
+function storeActivePage(page) {
+  try {
+    if (page) {
+      window.localStorage.setItem(ACTIVE_PAGE_STORAGE_KEY, page);
+    } else {
+      window.localStorage.removeItem(ACTIVE_PAGE_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn('Não foi possível salvar a página ativa.', error);
+  }
+}
+
+function getStoredActivePage() {
+  try {
+    return window.localStorage.getItem(ACTIVE_PAGE_STORAGE_KEY);
+  } catch (error) {
+    console.warn('Não foi possível recuperar a página ativa salva.', error);
+    return null;
+  }
+}
+
 function setActivePage(page) {
   sidebarButtons.forEach((button) => {
     const isActive = button.dataset.page === page;
@@ -39,4 +62,8 @@ function setActivePage(page) {
       detail: { page },
     }),
   );
+
+  storeActivePage(page);
 }
+
+window.getStoredActivePage = getStoredActivePage;

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -2,8 +2,6 @@ const events = {};
 let editingEvent = null;
 let editingEventOriginalDateKey = null;
 let currentDetailEvent = null;
-let detailAutoCloseTimeout = null;
-let isDetailHovered = false;
 let currentClientId = '';
 let currentClientData = null;
 
@@ -51,3 +49,52 @@ const MONTH_NAMES = [
 
 let currentCalendarDate = new Date();
 let currentCalendarView = 'month';
+
+function parseDateKeyToDate(dateKey) {
+  if (!dateKey) {
+    return null;
+  }
+  const normalized = String(dateKey).slice(0, 10);
+  const parsed = new Date(`${normalized}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  parsed.setHours(0, 0, 0, 0);
+  return parsed;
+}
+
+function formatPostSaleLabel(months) {
+  const numeric = Number(months);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '';
+  }
+  return `PV-${numeric}M`;
+}
+
+function getEventStatus(event) {
+  if (!event) {
+    return { key: 'pending', label: 'Pendente' };
+  }
+
+  const isContact = event.type === 'contact';
+  const isCompleted = isContact
+    ? Boolean(event.contactCompleted ?? event.completed)
+    : Boolean(event.completed);
+
+  if (isCompleted) {
+    return { key: 'completed', label: 'Efetuado' };
+  }
+
+  const eventDate = parseDateKeyToDate(event.date ?? event.rawDate ?? event.contactDate ?? null);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  if (eventDate && eventDate < today) {
+    return { key: 'overdue', label: 'Atrasado' };
+  }
+
+  return { key: 'pending', label: 'Pendente' };
+}
+
+window.getEventStatus = getEventStatus;
+window.formatPostSaleLabel = formatPostSaleLabel;

--- a/styles.css
+++ b/styles.css
@@ -806,30 +806,63 @@ body.modal-open {
 }
 
 .calendar__event-chip {
-  background-color: #ff9800;
   border-radius: 999px;
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 600;
-  color: #141414;
   border: none;
   cursor: pointer;
   transition: transform 0.2s ease;
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  text-align: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-align: left;
 }
 
-.calendar__event-chip--contact {
-  background-color: #22c55e;
-  color: #052e16;
+.calendar__event-chip--pending {
+  background-color: #facc15;
+  color: #422006;
 }
 
-.calendar__event-chip--contact.is-completed {
-  background-color: #14532d;
-  color: #ecfdf5;
+.calendar__event-chip--completed {
+  background-color: #86efac;
+  color: #064e3b;
+}
+
+.calendar__event-chip--overdue {
+  background-color: #f87171;
+  color: #7f1d1d;
+}
+
+.calendar__event-chip-label {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.calendar__event-chip-status {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.calendar__event-chip-status--pending {
+  background-color: #facc15;
+  border: 2px solid #d97706;
+}
+
+.calendar__event-chip-status--completed {
+  background-color: #86efac;
+  border: 2px solid #047857;
+}
+
+.calendar__event-chip-status--overdue {
+  background-color: #f87171;
+  border: 2px solid #b91c1c;
 }
 
 .calendar__event-chip:hover,
@@ -892,6 +925,31 @@ body.modal-open {
 .modal__title {
   font-size: 20px;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.modal__title-separator {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.modal__title-status {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.modal__title-status--pending {
+  color: #facc15;
+}
+
+.modal__title-status--completed {
+  color: #86efac;
+}
+
+.modal__title-status--overdue {
+  color: #f87171;
 }
 
 .modal__close {
@@ -1068,6 +1126,13 @@ body.modal-open {
   gap: 4px;
 }
 
+.modal__details-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .modal__details-value {
   color: #ffffff;
   font-size: 15px;
@@ -1140,32 +1205,30 @@ body.modal-open {
 }
 
 .modal__actions {
-  margin-left: auto;
-  margin-top: auto;
+  margin-top: 24px;
   display: flex;
-  gap: 10px;
+  justify-content: flex-end;
 }
 
-.modal__action {
-  background: transparent;
+.modal__status-button {
+  background-color: #2563eb;
+  color: #ffffff;
   border: none;
-  font-size: 22px;
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-weight: 600;
   cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  transition: background-color 0.2s ease;
 }
 
-.modal__action--edit {
-  color: #ff9800;
+.modal__status-button:hover,
+.modal__status-button:focus {
+  background-color: #1d4ed8;
 }
 
-.modal__action--delete {
-  color: #ff5252;
-}
-
-.modal__action--contact {
-  color: #22c55e;
+.modal__status-button:disabled {
+  opacity: 0.7;
+  cursor: progress;
 }
 
 .calendar__date--empty {


### PR DESCRIPTION
## Summary
- add completed state persistence and contact metadata to the events API responses
- rework calendar chips and the event/contact modal to surface status, contact information, and state toggles
- refresh styling for status dots, modal titles, and action buttons to reflect pending, completed, and overdue states

## Testing
- node --check backend/server.js
- node --check scripts/modals.js
- node --check scripts/calendar.js

------
https://chatgpt.com/codex/tasks/task_e_68e557714a588333a56faeef80095f1a