### PR TITLE
Evita recarregar página ao interagir com modais

### DIFF
--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -259,11 +259,24 @@ function getEventChipLabel(event) {
   return event.title || 'Evento';
 }
 
-function createStatusDot(statusKey) {
+function createStatusDot(typeKey, statusKey) {
   const dot = document.createElement('span');
-  dot.className = `calendar__event-chip-status calendar__event-chip-status--${statusKey}`;
+  dot.className = 'calendar__event-chip-status';
+  dot.dataset.dotType = typeKey;
+  dot.dataset.dotStatus = statusKey;
   dot.setAttribute('aria-hidden', 'true');
   return dot;
+}
+
+function getEventChipType(event) {
+  const rawType = typeof event?.type === 'string' ? event.type.toLowerCase() : '';
+  if (rawType === 'contact') {
+    return 'contact';
+  }
+  if (rawType === 'folga' || rawType === 'folgas' || rawType === 'dayoff' || rawType === 'day-off') {
+    return 'dayoff';
+  }
+  return 'event';
 }
 
 function renderEventsForCell(cell, dateKey) {
@@ -284,7 +297,10 @@ function renderEventsForCell(cell, dateKey) {
     const status = typeof getEventStatus === 'function'
       ? getEventStatus(event)
       : { key: 'pending', label: 'Pendente' };
-    chip.classList.add(`calendar__event-chip--${status.key}`);
+    const chipType = getEventChipType(event);
+    const chipVariant = status.key === 'completed' ? 'completed' : 'pending';
+    chip.dataset.chipType = chipType;
+    chip.dataset.chipVariant = chipVariant;
     chip.dataset.eventStatus = status.key;
 
     const labelElement = document.createElement('span');
@@ -292,7 +308,7 @@ function renderEventsForCell(cell, dateKey) {
     labelElement.textContent = getEventChipLabel(event);
     chip.appendChild(labelElement);
 
-    chip.appendChild(createStatusDot(status.key));
+    chip.appendChild(createStatusDot(chipType, status.key));
 
     const accessibleLabel = `${labelElement.textContent} - ${status.label}`;
     chip.setAttribute('aria-label', accessibleLabel);

--- a/scripts/clients.js
+++ b/scripts/clients.js
@@ -209,6 +209,17 @@ let isSavingQuickSale = false;
       lastPurchase: 180,
       acceptsContact: 180,
     },
+    detail: {
+      purchases: {
+        openId: null,
+        scrollTop: 0,
+      },
+      contacts: {
+        openPurchaseId: null,
+        focusedContactId: null,
+        scrollTop: 0,
+      },
+    },
   };
 
   let lastFilteredClients = [];
@@ -947,6 +958,14 @@ let isSavingQuickSale = false;
     return CLIENTS.find((client) => client.id === clientId) || null;
   }
 
+  function resetClientDetailState() {
+    state.detail.purchases.openId = null;
+    state.detail.purchases.scrollTop = 0;
+    state.detail.contacts.openPurchaseId = null;
+    state.detail.contacts.focusedContactId = null;
+    state.detail.contacts.scrollTop = 0;
+  }
+
   function renderClientDetail(client) {
     if (!clientDetailFields || !clientPurchasesContainer) {
       return;
@@ -1073,12 +1092,17 @@ let isSavingQuickSale = false;
   }
 
   function renderPurchaseHistory(client) {
+    const storedScrollTop = state.detail.purchases.scrollTop ?? clientPurchasesContainer.scrollTop;
+    const storedOpenId = state.detail.purchases.openId;
+
     clientPurchasesContainer.innerHTML = '';
     if (!client.purchases?.length) {
       const placeholder = document.createElement('div');
       placeholder.className = 'client-card__empty';
       placeholder.textContent = 'Nenhuma compra cadastrada.';
       clientPurchasesContainer.appendChild(placeholder);
+      state.detail.purchases.openId = null;
+      state.detail.purchases.scrollTop = 0;
       return;
     }
 
@@ -1090,7 +1114,15 @@ let isSavingQuickSale = false;
       .forEach((purchase) => {
         const article = document.createElement('article');
         article.className = 'client-purchase';
-        if (purchase === latestPurchase) {
+        const purchaseId = purchase.id ? String(purchase.id) : '';
+        if (purchaseId) {
+          article.dataset.purchaseId = purchaseId;
+        }
+        if (storedOpenId) {
+          if (purchaseId && purchaseId === storedOpenId) {
+            article.classList.add('is-open');
+          }
+        } else if (purchase === latestPurchase) {
           article.classList.add('is-open');
         }
 
@@ -1123,12 +1155,34 @@ let isSavingQuickSale = false;
         article.append(toggle, details);
         clientPurchasesContainer.appendChild(article);
       });
+
+    if (!clientPurchasesContainer.querySelector('.client-purchase.is-open')) {
+      const firstArticle = clientPurchasesContainer.querySelector('.client-purchase');
+      if (firstArticle) {
+        firstArticle.classList.add('is-open');
+      }
+    }
+
+    const openArticle = clientPurchasesContainer.querySelector('.client-purchase.is-open');
+    state.detail.purchases.openId = openArticle?.dataset.purchaseId ?? null;
+
+    const maxScrollTop = Math.max(
+      0,
+      clientPurchasesContainer.scrollHeight - clientPurchasesContainer.clientHeight,
+    );
+    const nextScrollTop = Math.min(Math.max(storedScrollTop, 0), maxScrollTop);
+    clientPurchasesContainer.scrollTop = nextScrollTop;
+    state.detail.purchases.scrollTop = nextScrollTop;
   }
 
   function renderClientContacts(client) {
     if (!clientContactHistoryContainer) {
       return;
     }
+
+    const storedScrollTop = state.detail.contacts.scrollTop ?? clientContactHistoryContainer.scrollTop;
+    const storedOpenPurchaseId = state.detail.contacts.openPurchaseId;
+    const storedFocusedContactId = state.detail.contacts.focusedContactId;
 
     clientContactHistoryContainer.innerHTML = '';
 
@@ -1146,8 +1200,13 @@ let isSavingQuickSale = false;
       placeholder.className = 'client-card__empty';
       placeholder.textContent = 'Nenhum contato registrado.';
       clientContactHistoryContainer.appendChild(placeholder);
+      state.detail.contacts.openPurchaseId = null;
+      state.detail.contacts.focusedContactId = null;
+      state.detail.contacts.scrollTop = 0;
       return;
     }
+
+    let buttonToFocus = null;
 
     purchasesWithContacts
       .slice()
@@ -1155,7 +1214,15 @@ let isSavingQuickSale = false;
       .forEach((purchase, index) => {
         const article = document.createElement('article');
         article.className = 'client-contact';
-        if (index === 0) {
+        const purchaseId = purchase.id ? String(purchase.id) : '';
+        if (purchaseId) {
+          article.dataset.purchaseId = purchaseId;
+        }
+        if (storedOpenPurchaseId) {
+          if (purchaseId && purchaseId === storedOpenPurchaseId) {
+            article.classList.add('is-open');
+          }
+        } else if (index === 0) {
           article.classList.add('is-open');
         }
 
@@ -1188,6 +1255,9 @@ let isSavingQuickSale = false;
           .forEach((contact) => {
             const item = document.createElement('div');
             item.className = 'client-contact__item';
+            if (contact.id) {
+              item.dataset.contactId = String(contact.id);
+            }
 
             const label = document.createElement('div');
             label.className = 'client-contact__label';
@@ -1205,6 +1275,9 @@ let isSavingQuickSale = false;
             if (contact.completed) {
               button.classList.add('is-completed');
             }
+            if (storedFocusedContactId && contact.id && String(contact.id) === storedFocusedContactId) {
+              buttonToFocus = button;
+            }
 
             item.append(label, button);
             list.appendChild(item);
@@ -1214,6 +1287,33 @@ let isSavingQuickSale = false;
         article.append(toggle, details);
         clientContactHistoryContainer.appendChild(article);
       });
+
+    if (!clientContactHistoryContainer.querySelector('.client-contact.is-open')) {
+      const firstArticle = clientContactHistoryContainer.querySelector('.client-contact');
+      if (firstArticle) {
+        firstArticle.classList.add('is-open');
+      }
+    }
+
+    const openArticle = clientContactHistoryContainer.querySelector('.client-contact.is-open');
+    state.detail.contacts.openPurchaseId = openArticle?.dataset.purchaseId ?? null;
+
+    const maxScrollTop = Math.max(
+      0,
+      clientContactHistoryContainer.scrollHeight - clientContactHistoryContainer.clientHeight,
+    );
+    const nextScrollTop = Math.min(Math.max(storedScrollTop, 0), maxScrollTop);
+    clientContactHistoryContainer.scrollTop = nextScrollTop;
+    state.detail.contacts.scrollTop = nextScrollTop;
+
+    if (buttonToFocus) {
+      try {
+        buttonToFocus.focus({ preventScroll: true });
+      } catch (error) {
+        buttonToFocus.focus();
+      }
+    }
+    state.detail.contacts.focusedContactId = null;
   }
 
   function updateQuickSaleButtonState(client) {
@@ -1337,7 +1437,10 @@ let isSavingQuickSale = false;
   }
 
   function handleQuickSaleOverlayClick(event) {
-    if (event.target === clientQuickSaleOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeQuickSaleModal();
     }
   }
@@ -1690,7 +1793,11 @@ let isSavingQuickSale = false;
 
     if (!isOpen) {
       article.classList.add('is-open');
+      state.detail.purchases.openId = article.dataset.purchaseId ?? null;
+    } else {
+      state.detail.purchases.openId = null;
     }
+    state.detail.purchases.scrollTop = clientPurchasesContainer?.scrollTop ?? 0;
   }
 
   function handleContactHistoryClick(event) {
@@ -1701,6 +1808,8 @@ let isSavingQuickSale = false;
 
     const toggle = target.closest('.client-contact__toggle');
     if (toggle) {
+      event.preventDefault();
+      event.stopPropagation();
       const article = toggle.closest('.client-contact');
       if (!article) {
         return;
@@ -1711,12 +1820,18 @@ let isSavingQuickSale = false;
         .forEach((contact) => contact.classList.remove('is-open'));
       if (!isOpen) {
         article.classList.add('is-open');
+        state.detail.contacts.openPurchaseId = article.dataset.purchaseId ?? null;
+      } else {
+        state.detail.contacts.openPurchaseId = null;
       }
+      state.detail.contacts.scrollTop = clientContactHistoryContainer?.scrollTop ?? 0;
       return;
     }
 
     const statusButton = target.closest('.client-contact__status');
     if (statusButton instanceof HTMLButtonElement) {
+      event.preventDefault();
+      event.stopPropagation();
       handleContactStatusButton(statusButton);
     }
   }
@@ -1726,6 +1841,14 @@ let isSavingQuickSale = false;
     if (!contactId) {
       return;
     }
+
+    const parentContact = button.closest('.client-contact');
+    state.detail.contacts.focusedContactId = contactId;
+    if (parentContact instanceof HTMLElement) {
+      state.detail.contacts.openPurchaseId = parentContact.dataset.purchaseId
+        ?? state.detail.contacts.openPurchaseId;
+    }
+    state.detail.contacts.scrollTop = clientContactHistoryContainer?.scrollTop ?? 0;
 
     const currentlyCompleted = button.dataset.completed === 'true';
     const nextValue = !currentlyCompleted;
@@ -2045,6 +2168,7 @@ let isSavingQuickSale = false;
 
       state.selectedIds.delete(client.id);
       setCurrentClient(null);
+      resetClientDetailState();
       updateQuickSaleButtonState(null);
       ensureDetailButtonState();
       renderClients();
@@ -2064,6 +2188,7 @@ let isSavingQuickSale = false;
   }
 
   function openClientDetail(client) {
+    resetClientDetailState();
     setCurrentClient(client);
     ensureDetailButtonState();
     renderClientDetail(client);
@@ -2244,7 +2369,13 @@ let isSavingQuickSale = false;
   });
 
   clientPurchasesContainer?.addEventListener('click', handlePurchaseToggle);
+  clientPurchasesContainer?.addEventListener('scroll', () => {
+    state.detail.purchases.scrollTop = clientPurchasesContainer.scrollTop;
+  });
   clientContactHistoryContainer?.addEventListener('click', handleContactHistoryClick);
+  clientContactHistoryContainer?.addEventListener('scroll', () => {
+    state.detail.contacts.scrollTop = clientContactHistoryContainer.scrollTop;
+  });
   clientQuickSaleButton?.addEventListener('click', openQuickSaleModal);
   clientQuickSaleCloseButton?.addEventListener('click', closeQuickSaleModal);
   clientQuickSaleCancelButton?.addEventListener('click', closeQuickSaleModal);
@@ -2264,7 +2395,10 @@ let isSavingQuickSale = false;
     clientsAdvancedForm.requestSubmit();
   });
   clientsAdvancedOverlay?.addEventListener('click', (event) => {
-    if (event.target === clientsAdvancedOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeAdvancedSearchModalInternal();
     }
   });
@@ -2276,7 +2410,10 @@ let isSavingQuickSale = false;
     });
   });
   clientInterestsOverlay?.addEventListener('click', (event) => {
-    if (event.target === clientInterestsOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeClientInterestsModalInternal();
     }
   });

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -69,7 +69,10 @@ homeAddEventCardButton?.addEventListener('click', () => {
 
 if (addEventOverlay) {
   addEventOverlay.addEventListener('click', (event) => {
-    if (event.target === addEventOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeAddEventModal();
     }
   });
@@ -90,7 +93,10 @@ addEventForm?.addEventListener('submit', (event) => {
 
 if (eventDetailsOverlay) {
   eventDetailsOverlay.addEventListener('click', (event) => {
-    if (event.target === eventDetailsOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeEventDetailsModal();
     }
   });
@@ -100,7 +106,9 @@ eventDetailsCloseButton?.addEventListener('click', () => {
   closeEventDetailsModal();
 });
 
-eventDetailsToggleStatusButton?.addEventListener('click', () => {
+eventDetailsToggleStatusButton?.addEventListener('click', (event) => {
+  event.preventDefault();
+  event.stopPropagation();
   handleToggleStatusFromModal();
 });
 

--- a/scripts/modals.js
+++ b/scripts/modals.js
@@ -227,45 +227,45 @@ function renderEventDetailsView() {
 
   if (event.type === 'contact') {
     const clientName = event.clientName || 'Cliente não informado';
-    eventDetailsBody.appendChild(createDetailsRow('Nome do cliente', `Nome: ${clientName}`));
+    eventDetailsBody.appendChild(createDetailsRow('Nome do cliente', clientName));
 
     const phone = formatPhoneNumber(event.clientPhone);
-    eventDetailsBody.appendChild(createDetailsRow('Telefone do cliente', `Telefone: ${phone}`));
+    eventDetailsBody.appendChild(createDetailsRow('Telefone do cliente', phone));
 
     const monthsLabel = typeof formatPostSaleLabel === 'function'
       ? formatPostSaleLabel(event.contactMonths ?? event.monthsOffset)
       : '';
-    const purchaseLabel = monthsLabel ? `Data da compra - (${monthsLabel})` : 'Data da compra';
+    const purchaseLabel = 'Data da compra';
     const purchaseDate = event.purchaseDate ? formatShortDate(event.purchaseDate) : '';
     const purchaseValue = purchaseDate
-      ? `Data da compra: ${purchaseDate}${monthsLabel ? ` - ${monthsLabel}` : ''}`
-      : 'Data da compra: Não informada';
+      ? `${purchaseDate}${monthsLabel ? ` - ${monthsLabel}` : ''}`
+      : 'Não informada';
     eventDetailsBody.appendChild(
       createDetailsRow(purchaseLabel, purchaseValue, { isEmpty: !purchaseDate })
     );
 
     const purchaseParts = [];
     if (event.purchaseFrame) {
-      purchaseParts.push(`Armação: ${event.purchaseFrame}`);
+      purchaseParts.push(`Armação ${event.purchaseFrame}`);
     }
     if (event.purchaseLens) {
-      purchaseParts.push(`Lente: ${event.purchaseLens}`);
+      purchaseParts.push(`Lente ${event.purchaseLens}`);
     }
     const purchaseText = purchaseParts.length
-      ? purchaseParts.join('  ')
+      ? purchaseParts.join(' · ')
       : 'Informações não disponíveis';
     eventDetailsBody.appendChild(
-      createDetailsRow('Compra do cliente', `Compra: ${purchaseText}`, {
+      createDetailsRow('Compra do cliente', purchaseText, {
         isEmpty: !purchaseParts.length,
       })
     );
   } else {
     const title = event.title || 'Evento';
-    eventDetailsBody.appendChild(createDetailsRow('Título do evento', `Título: ${title}`));
+    eventDetailsBody.appendChild(createDetailsRow('Título do evento', title));
 
     if (event.clientName) {
       eventDetailsBody.appendChild(
-        createDetailsRow('Cliente relacionado', `Cliente: ${event.clientName}`)
+        createDetailsRow('Cliente relacionado', event.clientName)
       );
     }
   }

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -131,7 +131,10 @@ function initializeUserSelector() {
   });
 
   userSelectorOverlay.addEventListener('click', (event) => {
-    if (event.target === userSelectorOverlay) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (!event.target.closest('.modal')) {
       closeUserSelectorModal();
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -810,7 +810,7 @@ body.modal-open {
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 600;
-  border: none;
+  border: 1px solid transparent;
   cursor: pointer;
   transition: transform 0.2s ease;
   width: 100%;
@@ -821,19 +821,34 @@ body.modal-open {
   text-align: left;
 }
 
-.calendar__event-chip--pending {
-  background-color: #facc15;
-  color: #422006;
+.calendar__event-chip[data-chip-type="event"][data-chip-variant="pending"] {
+  background-color: #fed7aa;
+  border-color: rgba(180, 83, 9, 0.35);
+  color: #431407;
 }
 
-.calendar__event-chip--completed {
-  background-color: #86efac;
+.calendar__event-chip[data-chip-type="event"][data-chip-variant="completed"] {
+  background-color: #ea580c;
+  border-color: rgba(194, 65, 12, 0.5);
+  color: #fff7ed;
+}
+
+.calendar__event-chip[data-chip-type="contact"][data-chip-variant="pending"] {
+  background-color: #bbf7d0;
+  border-color: rgba(22, 163, 74, 0.35);
   color: #064e3b;
 }
 
-.calendar__event-chip--overdue {
-  background-color: #f87171;
-  color: #7f1d1d;
+.calendar__event-chip[data-chip-type="contact"][data-chip-variant="completed"] {
+  background-color: #166534;
+  border-color: rgba(21, 128, 61, 0.55);
+  color: #ecfdf5;
+}
+
+.calendar__event-chip[data-chip-type="dayoff"] {
+  background-color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #0f172a;
 }
 
 .calendar__event-chip-label {
@@ -843,26 +858,52 @@ body.modal-open {
 }
 
 .calendar__event-chip-status {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
   margin-left: 12px;
+  border: 2px solid transparent;
+  box-shadow: 0 0 4px rgba(15, 23, 42, 0.4);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.calendar__event-chip-status--pending {
-  background-color: #facc15;
-  border: 2px solid #d97706;
+.calendar__event-chip-status[data-dot-type="event"][data-dot-status="pending"],
+.calendar__event-chip-status[data-dot-type="event"][data-dot-status="overdue"] {
+  background-color: #fcd34d;
+  border-color: #f59e0b;
+  box-shadow: 0 0 6px rgba(245, 158, 11, 0.65);
 }
 
-.calendar__event-chip-status--completed {
-  background-color: #86efac;
-  border: 2px solid #047857;
+.calendar__event-chip-status[data-dot-type="event"][data-dot-status="overdue"] {
+  background-color: #fb923c;
+  border-color: #c2410c;
+  box-shadow: 0 0 8px rgba(194, 65, 12, 0.7);
 }
 
-.calendar__event-chip-status--overdue {
-  background-color: #f87171;
-  border: 2px solid #b91c1c;
+.calendar__event-chip-status[data-dot-type="event"][data-dot-status="completed"] {
+  background-color: #f97316;
+  border-color: #9a3412;
+  box-shadow: 0 0 8px rgba(249, 115, 22, 0.7);
+}
+
+.calendar__event-chip-status[data-dot-type="contact"][data-dot-status="pending"],
+.calendar__event-chip-status[data-dot-type="contact"][data-dot-status="overdue"] {
+  background-color: #bbf7d0;
+  border-color: #34d399;
+  box-shadow: 0 0 7px rgba(52, 211, 153, 0.6);
+}
+
+.calendar__event-chip-status[data-dot-type="contact"][data-dot-status="completed"] {
+  background-color: #15803d;
+  border-color: #166534;
+  box-shadow: 0 0 8px rgba(22, 101, 52, 0.75);
+}
+
+.calendar__event-chip-status[data-dot-type="dayoff"] {
+  background-color: #f8fafc;
+  border-color: #cbd5f5;
+  box-shadow: 0 0 6px rgba(148, 163, 184, 0.5);
 }
 
 .calendar__event-chip:hover,
@@ -940,16 +981,10 @@ body.modal-open {
   font-weight: 700;
 }
 
-.modal__title-status--pending {
-  color: #facc15;
-}
-
-.modal__title-status--completed {
-  color: #86efac;
-}
-
+.modal__title-status--pending,
+.modal__title-status--completed,
 .modal__title-status--overdue {
-  color: #f87171;
+  color: inherit;
 }
 
 .modal__close {
@@ -2112,27 +2147,34 @@ body.modal-open {
   font-size: 13px;
 }
 
+
 .client-contact__status {
-  border: none;
+  border: 1px solid rgba(22, 163, 74, 0.25);
   border-radius: 999px;
   padding: 8px 16px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
-  background-color: rgba(34, 197, 94, 0.2);
-  color: #22c55e;
+  background-color: #bbf7d0;
+  color: #14532d;
 }
 
 .client-contact__status:hover,
 .client-contact__status:focus {
-  background-color: rgba(34, 197, 94, 0.35);
+  background-color: #a7f3d0;
   outline: none;
 }
 
 .client-contact__status.is-completed {
-  background-color: #15803d;
+  background-color: #166534;
+  border-color: rgba(21, 128, 61, 0.55);
   color: #ecfdf5;
+}
+
+.client-contact__status.is-completed:hover,
+.client-contact__status.is-completed:focus {
+  background-color: #15803d;
 }
 
 .client-contact__status:disabled {


### PR DESCRIPTION
## Summary
- impede que o botão de status do modal de eventos acione comportamentos padrão que fechavam a sobreposição
- bloqueia a propagação padrão nos botões da linha do contato para manter a página de cliente estável

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68e5676b6aec833391b19a18f8ce9922