### PR TITLE
Prevent modal buttons from triggering full page reloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,7 +958,7 @@
               <button class="modal__cancel-button" type="button" data-action="cancel-quick-sale">
                 Cancelar
               </button>
-              <button class="modal__save-button" type="submit" data-action="save-quick-sale">
+              <button class="modal__save-button" type="button" data-action="save-quick-sale">
                 Salvar
               </button>
             </div>
@@ -1011,7 +1011,7 @@
               <button class="modal__cancel-button" type="button" data-action="reset">
                 Limpar filtros
               </button>
-              <button class="modal__save-button" type="submit" data-action="apply">
+              <button class="modal__save-button" type="button" data-action="apply">
                 Aplicar filtros
               </button>
             </div>
@@ -1048,7 +1048,7 @@
               <button class="modal__cancel-button" type="button" data-action="cancel">
                 Cancelar
               </button>
-              <button class="modal__save-button" type="submit" data-action="save">
+              <button class="modal__save-button" type="button" data-action="save">
                 Salvar
               </button>
             </div>

--- a/scripts/clients.js
+++ b/scripts/clients.js
@@ -1445,8 +1445,7 @@ let isSavingQuickSale = false;
     }
   }
 
-  async function handleQuickSaleSubmit(event) {
-    event.preventDefault();
+  async function submitQuickSaleForm() {
     if (isSavingQuickSale) {
       return;
     }
@@ -1513,6 +1512,16 @@ let isSavingQuickSale = false;
       }
       isSavingQuickSale = false;
     }
+  }
+
+  async function handleQuickSaleSubmit(event) {
+    event.preventDefault();
+    await submitQuickSaleForm();
+  }
+
+  function handleQuickSaleSaveClick(event) {
+    event.preventDefault();
+    submitQuickSaleForm();
   }
 
   function ensureAdvancedSelectOptions() {
@@ -2379,6 +2388,7 @@ let isSavingQuickSale = false;
   clientQuickSaleButton?.addEventListener('click', openQuickSaleModal);
   clientQuickSaleCloseButton?.addEventListener('click', closeQuickSaleModal);
   clientQuickSaleCancelButton?.addEventListener('click', closeQuickSaleModal);
+  clientQuickSaleSaveButton?.addEventListener('click', handleQuickSaleSaveClick);
   clientQuickSaleOverlay?.addEventListener('click', handleQuickSaleOverlayClick);
   clientQuickSaleForm?.addEventListener('submit', handleQuickSaleSubmit);
   clientsDetailButton?.addEventListener('click', handleDetailButtonClick);


### PR DESCRIPTION
## Summary
- stop modal save buttons from submitting forms directly so they no longer reload the page
- refactor the quick-sale flow to reuse a shared submit routine
- trigger the shared routine from both the form submit event and the modal save button click

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e6596d4740833396660fc095b8b67b