### PR TITLE
Stop modal forms from reloading the SPA

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,12 @@
         </section>
 
         <section class="content__page" data-page="cadastro-cliente" data-label="Cadastro do cliente">
-          <form class="client-form" id="client-registration-form" autocomplete="off">
+          <form
+            class="client-form"
+            id="client-registration-form"
+            autocomplete="off"
+            data-prevent-reload="true"
+          >
             <fieldset class="client-form__section">
               <legend class="client-form__title">Dados pessoais</legend>
               <div class="client-form__grid">
@@ -919,7 +924,12 @@
           </button>
         </div>
         <div class="modal__content">
-          <form class="modal__form modal__form--quick-sale" data-role="client-quick-sale-form" autocomplete="off">
+          <form
+            class="modal__form modal__form--quick-sale"
+            data-role="client-quick-sale-form"
+            autocomplete="off"
+            data-prevent-reload="true"
+          >
             <label class="modal__field">
               <span class="modal__label">Data da compra</span>
               <input class="modal__input" type="date" name="saleDate" required />
@@ -958,7 +968,7 @@
               <button class="modal__cancel-button" type="button" data-action="cancel-quick-sale">
                 Cancelar
               </button>
-              <button class="modal__save-button" type="submit" data-action="save-quick-sale">
+              <button class="modal__save-button" type="button" data-action="save-quick-sale">
                 Salvar
               </button>
             </div>
@@ -985,7 +995,12 @@
           </button>
         </div>
         <div class="modal__content">
-          <form class="modal__form modal__form--advanced-search" data-role="clients-advanced-form" autocomplete="off">
+          <form
+            class="modal__form modal__form--advanced-search"
+            data-role="clients-advanced-form"
+            autocomplete="off"
+            data-prevent-reload="true"
+          >
             <label class="modal__field">
               <span class="modal__label">Tipo de usuário</span>
               <select class="modal__input" name="userType" data-advanced-select="userType"></select>
@@ -1011,7 +1026,7 @@
               <button class="modal__cancel-button" type="button" data-action="reset">
                 Limpar filtros
               </button>
-              <button class="modal__save-button" type="submit" data-action="apply">
+              <button class="modal__save-button" type="button" data-action="apply">
                 Aplicar filtros
               </button>
             </div>
@@ -1038,7 +1053,12 @@
           </button>
         </div>
         <div class="modal__content">
-          <form class="modal__form modal__form--interests" data-role="client-interests-form" autocomplete="off">
+          <form
+            class="modal__form modal__form--interests"
+            data-role="client-interests-form"
+            autocomplete="off"
+            data-prevent-reload="true"
+          >
             <p class="modal__helper-text">Escolha as etiquetas que representam melhor este cliente.</p>
             <fieldset class="modal__fieldset">
               <legend class="visually-hidden">Etiquetas disponíveis</legend>
@@ -1048,7 +1068,7 @@
               <button class="modal__cancel-button" type="button" data-action="cancel">
                 Cancelar
               </button>
-              <button class="modal__save-button" type="submit" data-action="save">
+              <button class="modal__save-button" type="button" data-action="save">
                 Salvar
               </button>
             </div>
@@ -1075,7 +1095,7 @@
           </button>
         </div>
         <div class="modal__content">
-          <form class="modal__form" autocomplete="off">
+          <form class="modal__form" autocomplete="off" data-prevent-reload="true">
             <label class="modal__field">
               <input class="modal__input" type="date" name="date" required />
             </label>
@@ -1165,7 +1185,11 @@
           </button>
         </div>
         <div class="modal__content">
-          <form class="modal__form modal__form--user-selector" autocomplete="off">
+          <form
+            class="modal__form modal__form--user-selector"
+            autocomplete="off"
+            data-prevent-reload="true"
+          >
             <fieldset class="user-selector">
               <legend class="visually-hidden">Opções de usuário</legend>
             </fieldset>
@@ -1184,6 +1208,7 @@
     <script src="scripts/api.js"></script>
     <script src="scripts/feedback.js"></script>
     <script src="scripts/elements.js"></script>
+    <script src="scripts/form-guards.js"></script>
     <script src="scripts/state.js"></script>
     <script src="scripts/users.js"></script>
     <script src="scripts/calendar.js"></script>

--- a/scripts/clients.js
+++ b/scripts/clients.js
@@ -1445,8 +1445,7 @@ let isSavingQuickSale = false;
     }
   }
 
-  async function handleQuickSaleSubmit(event) {
-    event.preventDefault();
+  async function submitQuickSaleForm() {
     if (isSavingQuickSale) {
       return;
     }
@@ -1513,6 +1512,16 @@ let isSavingQuickSale = false;
       }
       isSavingQuickSale = false;
     }
+  }
+
+  async function handleQuickSaleSubmit(event) {
+    event.preventDefault();
+    await submitQuickSaleForm();
+  }
+
+  function handleQuickSaleSaveClick(event) {
+    event.preventDefault();
+    submitQuickSaleForm();
   }
 
   function ensureAdvancedSelectOptions() {
@@ -2379,6 +2388,7 @@ let isSavingQuickSale = false;
   clientQuickSaleButton?.addEventListener('click', openQuickSaleModal);
   clientQuickSaleCloseButton?.addEventListener('click', closeQuickSaleModal);
   clientQuickSaleCancelButton?.addEventListener('click', closeQuickSaleModal);
+  clientQuickSaleSaveButton?.addEventListener('click', handleQuickSaleSaveClick);
   clientQuickSaleOverlay?.addEventListener('click', handleQuickSaleOverlayClick);
   clientQuickSaleForm?.addEventListener('submit', handleQuickSaleSubmit);
   clientsDetailButton?.addEventListener('click', handleDetailButtonClick);

--- a/scripts/form-guards.js
+++ b/scripts/form-guards.js
@@ -1,0 +1,67 @@
+'use strict';
+
+(function preventFormReloads() {
+  const ATTRIBUTE_NAME = 'preventReload';
+  const formsWithGuard = new WeakSet();
+
+  function shouldGuard(form) {
+    return form instanceof HTMLFormElement && form.dataset?.[ATTRIBUTE_NAME] === 'true';
+  }
+
+  function attachGuard(form) {
+    if (!shouldGuard(form) || formsWithGuard.has(form)) {
+      return;
+    }
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
+
+    formsWithGuard.add(form);
+  }
+
+  function scan(container = document) {
+    if (
+      !(
+        container instanceof Element
+        || container instanceof Document
+        || container instanceof DocumentFragment
+      )
+    ) {
+      return;
+    }
+
+    const forms = typeof container.querySelectorAll === 'function'
+      ? container.querySelectorAll(`form[data-${ATTRIBUTE_NAME}="true"]`)
+      : [];
+    forms.forEach((form) => attachGuard(form));
+
+    if (container instanceof HTMLFormElement) {
+      attachGuard(container);
+    } else if (container instanceof Element && container.matches?.(`form[data-${ATTRIBUTE_NAME}="true"]`)) {
+      attachGuard(container);
+    }
+  }
+
+  if (typeof MutationObserver === 'function') {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof Element || node instanceof DocumentFragment) {
+            scan(node);
+          }
+        });
+      }
+    });
+
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      scan();
+    });
+  } else {
+    scan();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a reusable data-prevent-reload flag to modal and client forms
- create a shared guard script that intercepts guarded form submissions and cancels the browser reload
- load the guard early so calendar and client dialogs keep their state while saving

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e6596d4740833396660fc095b8b67b