### PR TITLE
Prevent form reloads and keep modal state persistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,8 +152,8 @@
               </button>
               <button
                 class="topbar__button topbar__button--green"
-                type="submit"
-                form="client-registration-form"
+                type="button"
+                data-role="client-form-save"
               >
                 Salvar cadastro
               </button>
@@ -639,6 +639,14 @@
             autocomplete="off"
             data-prevent-reload="true"
           >
+            <div
+              class="inline-feedback"
+              data-role="inline-feedback"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden="true"
+            ></div>
             <fieldset class="client-form__section">
               <legend class="client-form__title">Dados pessoais</legend>
               <div class="client-form__grid">
@@ -930,6 +938,14 @@
             autocomplete="off"
             data-prevent-reload="true"
           >
+            <div
+              class="inline-feedback inline-feedback--modal"
+              data-role="inline-feedback"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden="true"
+            ></div>
             <label class="modal__field">
               <span class="modal__label">Data da compra</span>
               <input class="modal__input" type="date" name="saleDate" required />
@@ -1001,6 +1017,14 @@
             autocomplete="off"
             data-prevent-reload="true"
           >
+            <div
+              class="inline-feedback inline-feedback--modal"
+              data-role="inline-feedback"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden="true"
+            ></div>
             <label class="modal__field">
               <span class="modal__label">Tipo de usuário</span>
               <select class="modal__input" name="userType" data-advanced-select="userType"></select>
@@ -1059,6 +1083,14 @@
             autocomplete="off"
             data-prevent-reload="true"
           >
+            <div
+              class="inline-feedback inline-feedback--modal"
+              data-role="inline-feedback"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden="true"
+            ></div>
             <p class="modal__helper-text">Escolha as etiquetas que representam melhor este cliente.</p>
             <fieldset class="modal__fieldset">
               <legend class="visually-hidden">Etiquetas disponíveis</legend>
@@ -1096,6 +1128,14 @@
         </div>
         <div class="modal__content">
           <form class="modal__form" autocomplete="off" data-prevent-reload="true">
+            <div
+              class="inline-feedback inline-feedback--modal"
+              data-role="inline-feedback"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden="true"
+            ></div>
             <label class="modal__field">
               <input class="modal__input" type="date" name="date" required />
             </label>

--- a/scripts/clients.js
+++ b/scripts/clients.js
@@ -1424,6 +1424,9 @@ let isSavingQuickSale = false;
       clientQuickSaleSaveButton.disabled = false;
     }
     isSavingQuickSale = false;
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientQuickSaleForm);
+    }
     closeOverlay(clientQuickSaleOverlay);
   }
 
@@ -1433,6 +1436,9 @@ let isSavingQuickSale = false;
       return;
     }
     prepareQuickSaleForm(client);
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientQuickSaleForm);
+    }
     openOverlay(clientQuickSaleOverlay);
   }
 
@@ -1451,6 +1457,10 @@ let isSavingQuickSale = false;
     }
     if (!clientQuickSaleForm?.reportValidity()) {
       return;
+    }
+
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientQuickSaleForm);
     }
 
     const client = getCurrentClientData();
@@ -1498,13 +1508,20 @@ let isSavingQuickSale = false;
       if (typeof window.showToast === 'function') {
         window.showToast(successMessage, { type: 'success' });
       }
+      if (typeof window.showInlineFeedback === 'function') {
+        window.showInlineFeedback(clientQuickSaleForm, successMessage, {
+          type: 'success',
+        });
+      }
 
-      closeQuickSaleModal();
-      setActivePage('cliente-detalhe');
+      prepareQuickSaleForm(updatedClient);
     } catch (error) {
       const message = getApiErrorMessage(error, errorMessage);
       if (typeof window.showToast === 'function') {
         window.showToast(message, { type: 'error' });
+      }
+      if (typeof window.showInlineFeedback === 'function') {
+        window.showInlineFeedback(clientQuickSaleForm, message, { type: 'error' });
       }
     } finally {
       if (clientQuickSaleSaveButton) {
@@ -1934,6 +1951,9 @@ let isSavingQuickSale = false;
       return;
     }
     clientFormElement.reset();
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientFormElement);
+    }
     clientFormElement.dataset.mode = mode;
     if (client?.id) {
       clientFormElement.dataset.clientId = client.id;
@@ -2046,6 +2066,10 @@ let isSavingQuickSale = false;
       return;
     }
 
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientFormElement);
+    }
+
     const data = collectFormData();
     if (!data) {
       return;
@@ -2103,6 +2127,7 @@ let isSavingQuickSale = false;
         const updatedClient = upsertClientFromApi(apiClient);
         setCurrentClient(updatedClient);
         renderClientDetail(updatedClient);
+        prepareClientForm('edit', updatedClient);
       } else {
         const response = await window.api.createClient(apiPayload);
         const apiClient = response?.cliente;
@@ -2113,20 +2138,28 @@ let isSavingQuickSale = false;
         const createdClient = upsertClientFromApi(apiClient, { preferPrepend: true });
         setCurrentClient(createdClient);
         renderClientDetail(createdClient);
+        prepareClientForm('edit', createdClient);
       }
 
       if (typeof window.showToast === 'function') {
         window.showToast(successMessage, { type: 'success' });
       }
+      if (typeof window.showInlineFeedback === 'function') {
+        window.showInlineFeedback(clientFormElement, successMessage, {
+          type: 'success',
+        });
+      }
 
       renderClients();
       ensureDetailButtonState();
       updateQuickSaleButtonState(getCurrentClientData());
-      setActivePage('clientes');
     } catch (error) {
       const message = getApiErrorMessage(error, errorMessage);
       if (typeof window.showToast === 'function') {
         window.showToast(message, { type: 'error' });
+      }
+      if (typeof window.showInlineFeedback === 'function') {
+        window.showInlineFeedback(clientFormElement, message, { type: 'error' });
       }
     } finally {
       isSavingClient = false;
@@ -2205,6 +2238,9 @@ let isSavingQuickSale = false;
   }
 
   function closeAdvancedSearchModalInternal() {
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientsAdvancedForm);
+    }
     closeOverlay(clientsAdvancedOverlay);
   }
 
@@ -2213,6 +2249,9 @@ let isSavingQuickSale = false;
     ensureInterestCheckboxes(clientsAdvancedInterestsContainer, 'advancedInterests');
     if (!clientsAdvancedOverlay) {
       return;
+    }
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientsAdvancedForm);
     }
     if (clientsAdvancedForm) {
       const userTypeField = clientsAdvancedForm.elements.namedItem('userType');
@@ -2242,6 +2281,9 @@ let isSavingQuickSale = false;
     if (!clientsAdvancedForm) {
       return;
     }
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientsAdvancedForm);
+    }
     const formData = new FormData(clientsAdvancedForm);
     const userTypeValue = formData.get('userType');
     const clientStateValue = formData.get('clientState');
@@ -2263,12 +2305,19 @@ let isSavingQuickSale = false;
     state.page = 1;
     renderClients();
     updateAdvancedButtonState();
-    closeAdvancedSearchModalInternal();
+    if (typeof window.showInlineFeedback === 'function') {
+      window.showInlineFeedback(clientsAdvancedForm, 'Filtros aplicados com sucesso.', {
+        type: 'success',
+      });
+    }
   }
 
   function handleAdvancedReset() {
     if (!clientsAdvancedForm) {
       return;
+    }
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientsAdvancedForm);
     }
     state.filters.userType = '';
     state.filters.clientState = '';
@@ -2283,6 +2332,9 @@ let isSavingQuickSale = false;
   }
 
   function closeClientInterestsModalInternal() {
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientInterestsForm);
+    }
     closeOverlay(clientInterestsOverlay);
   }
 
@@ -2293,14 +2345,19 @@ let isSavingQuickSale = false;
     }
     ensureInterestCheckboxes(clientInterestsOptionsContainer, 'interests');
     setCheckboxSelections(clientInterestsOptionsContainer, client.interests);
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientInterestsForm);
+    }
     openOverlay(clientInterestsOverlay);
   }
 
   function handleClientInterestsSubmit(event) {
     event.preventDefault();
+    if (typeof window.clearInlineFeedback === 'function') {
+      window.clearInlineFeedback(clientInterestsForm);
+    }
     const client = getCurrentClientData();
     if (!client || !clientInterestsForm) {
-      closeClientInterestsModalInternal();
       return;
     }
     const formData = new FormData(clientInterestsForm);
@@ -2312,7 +2369,11 @@ let isSavingQuickSale = false;
     renderClientInterests(client);
     renderClients();
     updateAdvancedButtonState();
-    closeClientInterestsModalInternal();
+    if (typeof window.showInlineFeedback === 'function') {
+      window.showInlineFeedback(clientInterestsForm, 'Interesses atualizados com sucesso.', {
+        type: 'success',
+      });
+    }
   }
 
   window.navigateToClientDetail = (clientId) => {
@@ -2437,6 +2498,9 @@ let isSavingQuickSale = false;
   });
   clientFormElement?.addEventListener('submit', handleClientFormSubmit);
   clientFormCancelButton?.addEventListener('click', handleClientDetailBack);
+  clientFormSaveButton?.addEventListener('click', () => {
+    clientFormElement?.requestSubmit();
+  });
   clientDetailBackButton?.addEventListener('click', handleClientDetailBack);
   clientDetailEditButton?.addEventListener('click', handleClientDetailEdit);
   clientDetailDeleteButton?.addEventListener('click', handleClientDetailDelete);

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -41,6 +41,7 @@ const clientInterestsContainer = clientDetailElement?.querySelector('[data-role=
 const clientInterestsEditButton = document.querySelector('[data-role="client-interests-edit"]');
 const clientFormElement = document.querySelector('#client-registration-form');
 const clientFormCancelButton = document.querySelector('[data-role="client-form-cancel"]');
+const clientFormSaveButton = document.querySelector('[data-role="client-form-save"]');
 const clientsAdvancedSearchButton = document.querySelector('[data-role="clients-advanced-search"]');
 const clientsAdvancedOverlay = document.querySelector('[data-modal="clients-advanced-search"]');
 const clientsAdvancedForm = clientsAdvancedOverlay?.querySelector('[data-role="clients-advanced-form"]');

--- a/scripts/feedback.js
+++ b/scripts/feedback.js
@@ -50,4 +50,85 @@
   }
 
   window.showToast = showToast;
+
+  const inlineFeedbackTimeouts = new WeakMap();
+  const INLINE_FEEDBACK_SELECTOR = '[data-role="inline-feedback"]';
+
+  function findInlineFeedbackContainer(target) {
+    if (!(target instanceof Element)) {
+      return null;
+    }
+
+    if (target.matches(INLINE_FEEDBACK_SELECTOR)) {
+      return target;
+    }
+
+    const directChild = target.querySelector(INLINE_FEEDBACK_SELECTOR);
+    if (directChild) {
+      return directChild;
+    }
+
+    if (target.closest) {
+      return target.closest(INLINE_FEEDBACK_SELECTOR);
+    }
+
+    return null;
+  }
+
+  function clearInlineFeedback(target) {
+    const container = findInlineFeedbackContainer(target);
+    if (!container) {
+      return;
+    }
+
+    const timeoutId = inlineFeedbackTimeouts.get(container);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      inlineFeedbackTimeouts.delete(container);
+    }
+
+    container.textContent = '';
+    container.classList.remove(
+      'inline-feedback--visible',
+      'inline-feedback--success',
+      'inline-feedback--error',
+      'inline-feedback--info',
+    );
+    container.setAttribute('aria-hidden', 'true');
+  }
+
+  function showInlineFeedback(target, message, { type = 'success', duration = 4000 } = {}) {
+    if (!message) {
+      return;
+    }
+
+    const container = findInlineFeedbackContainer(target);
+    if (!container) {
+      return;
+    }
+
+    const timeoutId = inlineFeedbackTimeouts.get(container);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    container.textContent = message;
+    container.classList.remove('inline-feedback--success', 'inline-feedback--error', 'inline-feedback--info');
+    container.classList.add(`inline-feedback--${type}`, 'inline-feedback--visible');
+    container.setAttribute('aria-hidden', 'false');
+
+    if (duration > 0) {
+      const newTimeout = setTimeout(() => {
+        container.classList.remove('inline-feedback--visible');
+        container.setAttribute('aria-hidden', 'true');
+        inlineFeedbackTimeouts.delete(container);
+      }, duration);
+      inlineFeedbackTimeouts.set(container, newTimeout);
+    } else {
+      inlineFeedbackTimeouts.delete(container);
+    }
+  }
+
+  window.showInlineFeedback = showInlineFeedback;
+  window.clearInlineFeedback = clearInlineFeedback;
 })();

--- a/scripts/form-guards.js
+++ b/scripts/form-guards.js
@@ -1,11 +1,29 @@
 'use strict';
 
 (function preventFormReloads() {
-  const ATTRIBUTE_NAME = 'preventReload';
+  const ATTRIBUTE_NAME = 'data-prevent-reload';
   const formsWithGuard = new WeakSet();
 
   function shouldGuard(form) {
-    return form instanceof HTMLFormElement && form.dataset?.[ATTRIBUTE_NAME] === 'true';
+    if (!(form instanceof HTMLFormElement)) {
+      return false;
+    }
+
+    if (!form.hasAttribute(ATTRIBUTE_NAME)) {
+      return false;
+    }
+
+    const rawValue = form.getAttribute(ATTRIBUTE_NAME);
+    if (rawValue === null) {
+      return false;
+    }
+
+    const normalized = rawValue.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+
+    return true;
   }
 
   function attachGuard(form) {
@@ -32,13 +50,13 @@
     }
 
     const forms = typeof container.querySelectorAll === 'function'
-      ? container.querySelectorAll(`form[data-${ATTRIBUTE_NAME}="true"]`)
+      ? container.querySelectorAll(`form[${ATTRIBUTE_NAME}]`)
       : [];
     forms.forEach((form) => attachGuard(form));
 
     if (container instanceof HTMLFormElement) {
       attachGuard(container);
-    } else if (container instanceof Element && container.matches?.(`form[data-${ATTRIBUTE_NAME}="true"]`)) {
+    } else if (container instanceof Element && container.matches?.(`form[${ATTRIBUTE_NAME}]`)) {
       attachGuard(container);
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -2490,6 +2490,43 @@ body.modal-open {
   background-color: #ffb74d;
 }
 
+.inline-feedback {
+  display: none;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.45;
+  background-color: rgba(33, 33, 33, 0.85);
+  color: #ffffff;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.inline-feedback--modal {
+  margin-bottom: 12px;
+}
+
+.inline-feedback--visible {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.inline-feedback--success {
+  background-color: rgba(46, 125, 50, 0.9);
+}
+
+.inline-feedback--error {
+  background-color: rgba(198, 40, 40, 0.9);
+}
+
+.inline-feedback--info {
+  background-color: rgba(25, 118, 210, 0.9);
+}
+
 .toast-container {
   position: fixed;
   top: 24px;


### PR DESCRIPTION
## Summary
- add inline feedback containers and change submit buttons to preserve SPA context without reloading
- implement global form guard, async save updates, and inline messaging across clients, quick-sale, and advanced search flows
- keep modals open after saving while refreshing in-place data and extend modal helpers to manage inline feedback

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e660f0d98483338127a7f820c1a2a0