### PR TITLE
Prevent modal submissions from reloading the page

### DIFF
--- a/scripts/clients.js
+++ b/scripts/clients.js
@@ -2305,6 +2305,9 @@ let isSavingQuickSale = false;
     state.page = 1;
     renderClients();
     updateAdvancedButtonState();
+    if (typeof window.showToast === 'function') {
+      window.showToast('Filtros aplicados com sucesso.', { type: 'success' });
+    }
     if (typeof window.showInlineFeedback === 'function') {
       window.showInlineFeedback(clientsAdvancedForm, 'Filtros aplicados com sucesso.', {
         type: 'success',
@@ -2369,6 +2372,9 @@ let isSavingQuickSale = false;
     renderClientInterests(client);
     renderClients();
     updateAdvancedButtonState();
+    if (typeof window.showToast === 'function') {
+      window.showToast('Interesses atualizados com sucesso.', { type: 'success' });
+    }
     if (typeof window.showInlineFeedback === 'function') {
       window.showInlineFeedback(clientInterestsForm, 'Interesses atualizados com sucesso.', {
         type: 'success',

--- a/scripts/form-guards.js
+++ b/scripts/form-guards.js
@@ -2,20 +2,39 @@
 
 (function preventFormReloads() {
   const ATTRIBUTE_NAME = 'data-prevent-reload';
+  const ALLOW_SUBMIT_ATTRIBUTE = 'data-allow-submit';
   const formsWithGuard = new WeakSet();
+
+  function allowsNativeSubmit(form) {
+    if (!form.hasAttribute(ALLOW_SUBMIT_ATTRIBUTE)) {
+      return false;
+    }
+
+    const rawValue = form.getAttribute(ALLOW_SUBMIT_ATTRIBUTE);
+    if (rawValue === null) {
+      return true;
+    }
+
+    const normalized = rawValue.trim().toLowerCase();
+    return normalized === '' || normalized === 'true' || normalized === '1';
+  }
 
   function shouldGuard(form) {
     if (!(form instanceof HTMLFormElement)) {
       return false;
     }
 
-    if (!form.hasAttribute(ATTRIBUTE_NAME)) {
+    if (allowsNativeSubmit(form)) {
       return false;
+    }
+
+    if (!form.hasAttribute(ATTRIBUTE_NAME)) {
+      return true;
     }
 
     const rawValue = form.getAttribute(ATTRIBUTE_NAME);
     if (rawValue === null) {
-      return false;
+      return true;
     }
 
     const normalized = rawValue.trim().toLowerCase();
@@ -26,15 +45,34 @@
     return true;
   }
 
+  function normalizeActionButtons(form) {
+    const buttons = form.querySelectorAll('button');
+    buttons.forEach((button) => {
+      const currentType = button.getAttribute('type');
+      const normalized = currentType ? currentType.trim().toLowerCase() : '';
+      if (!normalized || normalized === 'submit') {
+        button.setAttribute('type', 'button');
+      }
+    });
+
+    const submitInputs = form.querySelectorAll('input[type="submit"]');
+    submitInputs.forEach((input) => {
+      input.setAttribute('type', 'button');
+    });
+  }
+
   function attachGuard(form) {
     if (!shouldGuard(form) || formsWithGuard.has(form)) {
       return;
     }
 
     form.addEventListener('submit', (event) => {
-      event.preventDefault();
+      if (!event.defaultPrevented) {
+        event.preventDefault();
+      }
     });
 
+    normalizeActionButtons(form);
     formsWithGuard.add(form);
   }
 
@@ -50,13 +88,11 @@
     }
 
     const forms = typeof container.querySelectorAll === 'function'
-      ? container.querySelectorAll(`form[${ATTRIBUTE_NAME}]`)
+      ? container.querySelectorAll('form')
       : [];
     forms.forEach((form) => attachGuard(form));
 
     if (container instanceof HTMLFormElement) {
-      attachGuard(container);
-    } else if (container instanceof Element && container.matches?.(`form[${ATTRIBUTE_NAME}]`)) {
       attachGuard(container);
     }
   }
@@ -64,7 +100,18 @@
   if (typeof MutationObserver === 'function') {
     const observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
+        if (mutation.target instanceof HTMLFormElement) {
+          attachGuard(mutation.target);
+          normalizeActionButtons(mutation.target);
+        }
+
         mutation.addedNodes.forEach((node) => {
+          if (node instanceof HTMLFormElement) {
+            attachGuard(node);
+            normalizeActionButtons(node);
+            return;
+          }
+
           if (node instanceof Element || node instanceof DocumentFragment) {
             scan(node);
           }

--- a/scripts/modals.js
+++ b/scripts/modals.js
@@ -348,59 +348,6 @@ function renderEventDetailsView() {
     }
   }
 }
-// Captura o botão de status
-// Escuta o clique de QUALQUER botão de status, mesmo que ele seja criado depois
-document.addEventListener('click', async (e) => {
-  const btn = e.target.closest('.modal__status-button');
-  if (!btn) return; // ignora outros cliques
-
-  e.preventDefault();
-  e.stopPropagation();
-
-  const entityType = btn.dataset.entityType;
-  const eventId = btn.dataset.eventId;
-  const contactId = btn.dataset.contactId;
-  const statusKey = btn.dataset.statusKey;
-  const novoStatus = statusKey === 'completed' ? 'pending' : 'completed';
-
-  try {
-    const res = await fetch('/api/eventos/toggle', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        entityType,
-        eventId,
-        contactId,
-        status: novoStatus
-      })
-    });
-
-    if (!res.ok) throw new Error('Erro na atualização');
-    const data = await res.json();
-
-    // Atualiza visualmente o evento no calendário
-    if (typeof atualizarEventoNaTela === 'function') {
-      atualizarEventoNaTela(data);
-    }
-
-    // Mostra feedback visual
-    if (typeof mostrarToast === 'function') {
-      mostrarToast(`Evento marcado como ${novoStatus === 'completed' ? 'Efetuado' : 'Pendente'}`);
-    }
-
-    // Atualiza o texto do botão
-    btn.textContent =
-      novoStatus === 'completed' ? 'Marcar como Pendente' : 'Marcar como Efetuado';
-    btn.dataset.statusKey = novoStatus;
-  } catch (err) {
-    console.error('Erro ao alternar status:', err);
-    if (typeof mostrarToast === 'function') {
-      mostrarToast('Erro ao atualizar evento');
-    }
-  }
-});
-
-
 function openEventDetailsModal(event) {
   if (!eventDetailsOverlay || !eventDetailsBody) {
     return;

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -114,6 +114,9 @@ function handleUserSelectorSubmit(event) {
   }
 
   setCurrentUser(selectedUserId);
+  if (typeof window.showToast === 'function') {
+    window.showToast(`Usuário alterado para ${selectedUser.name}.`, { type: 'success' });
+  }
   closeUserSelectorModal();
 }
 


### PR DESCRIPTION
## Summary
- expand the form guard to attach to every form, preventing default submissions and normalizing button types for SPA behaviour
- remove the legacy global modal status handler that performed direct fetches and could close or refresh modals unexpectedly
- surface consistent toast confirmations after client filter updates, interest saves, and user changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66f60e49483338c36b87c7552614e