### PR TITLE
feat: add SPA core infrastructure and stronger guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1247,6 +1247,9 @@
     </div>
     <script src="scripts/api.js"></script>
     <script src="scripts/feedback.js"></script>
+    <script src="scripts/core/state.js"></script>
+    <script src="scripts/core/router.js"></script>
+    <script src="scripts/core/net.js"></script>
     <script src="scripts/elements.js"></script>
     <script src="scripts/form-guards.js"></script>
     <script src="scripts/state.js"></script>

--- a/scripts/core/net.js
+++ b/scripts/core/net.js
@@ -1,0 +1,169 @@
+(function (global) {
+  const DEFAULT_TIMEOUT = 15000;
+  const NETWORK_EVENT = 'network:loading';
+
+  function toError(error, { url, options, response } = {}) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    const normalized = new Error('Ocorreu um erro desconhecido.');
+    normalized.original = error;
+    if (url) {
+      normalized.url = url;
+    }
+    if (options) {
+      normalized.options = options;
+    }
+    if (response) {
+      normalized.response = response;
+    }
+    return normalized;
+  }
+
+  function parseBody(response, parse) {
+    if (parse === false) {
+      return Promise.resolve(null);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    const wantsJson = parse === 'json' || (parse === undefined && contentType.includes('application/json'));
+
+    if (wantsJson) {
+      return response
+        .json()
+        .catch(() => null);
+    }
+
+    if (parse === 'text') {
+      return response.text();
+    }
+
+    return Promise.resolve(null);
+  }
+
+  function emitLoading(loading, detail) {
+    const appState = global.AppState;
+    if (appState && typeof appState.notify === 'function') {
+      appState.notify(NETWORK_EVENT, { loading, ...detail });
+    }
+
+    document.dispatchEvent(
+      new CustomEvent(NETWORK_EVENT, {
+        detail: { loading, ...detail },
+      }),
+    );
+  }
+
+  async function safeFetch(url, options = {}) {
+    const {
+      method = 'GET',
+      headers,
+      body,
+      timeout = DEFAULT_TIMEOUT,
+      parse = 'json',
+      onStart,
+      onFinish,
+      signal,
+      credentials,
+    } = options;
+
+    const requestHeaders = new Headers(headers || {});
+    const isJsonBody = body && typeof body === 'object' && !(body instanceof FormData) && !(body instanceof Blob);
+
+    if (isJsonBody && !requestHeaders.has('Content-Type')) {
+      requestHeaders.set('Content-Type', 'application/json');
+    }
+
+    if (!requestHeaders.has('Accept')) {
+      requestHeaders.set('Accept', 'application/json');
+    }
+
+    const controller = new AbortController();
+    if (signal instanceof AbortSignal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+      } else {
+        signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+      }
+    }
+
+    let timeoutId = null;
+    if (Number.isFinite(timeout) && timeout > 0) {
+      timeoutId = global.setTimeout(() => {
+        controller.abort(new DOMException('Tempo limite atingido.', 'AbortError'));
+      }, timeout);
+    }
+
+    const fetchOptions = {
+      method,
+      headers: requestHeaders,
+      body: isJsonBody ? JSON.stringify(body) : body,
+      signal: controller.signal,
+    };
+
+    if (credentials) {
+      fetchOptions.credentials = credentials;
+    }
+
+    const detail = { url, method };
+
+    try {
+      if (typeof onStart === 'function') {
+        onStart(detail);
+      }
+      emitLoading(true, detail);
+
+      const response = await global.fetch(url, fetchOptions);
+      const data = await parseBody(response, parse);
+      const result = Object.freeze({
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        data,
+      });
+
+      if (!response.ok) {
+        const error = toError(data?.error || data?.message || response.statusText || 'Erro na requisição.', {
+          url,
+          options,
+          response,
+        });
+        error.status = response.status;
+        error.data = data;
+        if (typeof global.showError === 'function') {
+          global.showError(error);
+          error.__toastShown = true;
+        }
+        throw error;
+      }
+
+      return result;
+    } catch (cause) {
+      const error = toError(cause, { url, options });
+      if (error.name === 'AbortError') {
+        error.message = error.message || 'Requisição cancelada.';
+      } else if (!error.message) {
+        error.message = 'Falha na requisição.';
+      }
+
+      if (typeof global.showError === 'function' && !error.__toastShown) {
+        global.showError(error);
+        error.__toastShown = true;
+      }
+
+      throw error;
+    } finally {
+      if (timeoutId) {
+        global.clearTimeout(timeoutId);
+      }
+      emitLoading(false, detail);
+      if (typeof onFinish === 'function') {
+        onFinish(detail);
+      }
+    }
+  }
+
+  global.safeFetch = safeFetch;
+})(window);

--- a/scripts/core/router.js
+++ b/scripts/core/router.js
@@ -1,0 +1,155 @@
+(function (global) {
+  const ROUTE_EVENT = 'route:change';
+  const DEFAULT_VIEW = 'home';
+
+  const routes = [
+    {
+      name: 'clientes',
+      pattern: /^#\/?clientes\/([^/]+)$/i,
+      resolve(matches) {
+        const clientId = decodeURIComponent(matches[1] || '');
+        return {
+          view: 'clientes',
+          params: { clientId },
+          state: {
+            currentView: 'clientes',
+            currentClientId: clientId,
+            currentEventId: null,
+          },
+        };
+      },
+    },
+    {
+      name: 'calendario',
+      pattern: /^#\/?calendario(?:\/eventos\/([^/]+))?$/i,
+      resolve(matches) {
+        const eventId = matches[1] ? decodeURIComponent(matches[1]) : null;
+        return {
+          view: 'calendario',
+          params: { eventId },
+          state: {
+            currentView: 'calendario',
+            currentEventId: eventId,
+          },
+        };
+      },
+    },
+  ];
+
+  function createRouteResult(hash) {
+    if (!hash) {
+      return {
+        name: DEFAULT_VIEW,
+        view: DEFAULT_VIEW,
+        params: {},
+        state: { currentView: DEFAULT_VIEW },
+      };
+    }
+
+    for (const route of routes) {
+      const matches = hash.match(route.pattern);
+      if (matches) {
+        const result = route.resolve(matches) || {};
+        return {
+          name: route.name,
+          view: result.view || route.name,
+          params: result.params || {},
+          state: result.state || {},
+        };
+      }
+    }
+
+    return {
+      name: DEFAULT_VIEW,
+      view: DEFAULT_VIEW,
+      params: {},
+      state: { currentView: DEFAULT_VIEW },
+    };
+  }
+
+  function emitRoute(result) {
+    const appState = global.AppState;
+    if (appState && typeof appState.setState === 'function') {
+      appState.setState(result.state || {});
+    }
+
+    if (appState && typeof appState.notify === 'function') {
+      appState.notify(ROUTE_EVENT, result);
+    }
+
+    document.dispatchEvent(
+      new CustomEvent(ROUTE_EVENT, {
+        detail: result,
+      }),
+    );
+  }
+
+  function handleRouteChange() {
+    const hash = global.location.hash || '';
+    const result = createRouteResult(hash);
+    emitRoute(result);
+  }
+
+  function normalizeHashFromState(state) {
+    const view = state.currentView || DEFAULT_VIEW;
+    if (view === 'clientes' && state.currentClientId) {
+      return `#/clientes/${encodeURIComponent(state.currentClientId)}`;
+    }
+    if (view === 'calendario') {
+      if (state.currentEventId) {
+        return `#/calendario/eventos/${encodeURIComponent(state.currentEventId)}`;
+      }
+      return '#/calendario';
+    }
+    if (view && view !== DEFAULT_VIEW) {
+      return `#/${view}`;
+    }
+    return '#/';
+  }
+
+  function syncHashWithState() {
+    const appState = global.AppState;
+    if (!appState || typeof appState.getState !== 'function') {
+      return;
+    }
+
+    const state = appState.getState();
+    const nextHash = normalizeHashFromState(state);
+    if (global.location.hash !== nextHash) {
+      global.location.hash = nextHash;
+    }
+  }
+
+  function setupStateListener() {
+    const appState = global.AppState;
+    if (!appState || typeof appState.subscribe !== 'function') {
+      return;
+    }
+
+    appState.subscribe('change:currentView', syncHashWithState);
+    appState.subscribe('change:currentClientId', syncHashWithState);
+    appState.subscribe('change:currentEventId', syncHashWithState);
+  }
+
+  function init() {
+    setupStateListener();
+    if (!global.location.hash) {
+      syncHashWithState();
+    } else {
+      handleRouteChange();
+    }
+  }
+
+  global.SPARouter = Object.freeze({
+    init,
+    handleRouteChange,
+  });
+
+  global.addEventListener('hashchange', handleRouteChange);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(window);

--- a/scripts/core/state.js
+++ b/scripts/core/state.js
@@ -1,0 +1,187 @@
+(function (global) {
+  const STORAGE_KEY = 'crm-spa-state';
+  const PERSISTED_KEYS = new Set([
+    'currentView',
+    'currentClientId',
+    'currentEventId',
+    'filters',
+    'user',
+  ]);
+
+  const defaultState = Object.freeze({
+    currentView: 'home',
+    currentClientId: null,
+    currentEventId: null,
+    filters: Object.freeze({}),
+    user: null,
+  });
+
+  function safeParse(json) {
+    if (!json || typeof json !== 'string') {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(json);
+      return typeof parsed === 'object' && parsed ? parsed : {};
+    } catch (error) {
+      console.warn('[state] Falha ao ler sessionStorage.', error);
+      return {};
+    }
+  }
+
+  function readPersistedState() {
+    try {
+      const storedValue = global.sessionStorage?.getItem(STORAGE_KEY);
+      return safeParse(storedValue);
+    } catch (error) {
+      console.warn('[state] sessionStorage indisponível.', error);
+      return {};
+    }
+  }
+
+  const internalState = {
+    ...defaultState,
+    ...readPersistedState(),
+  };
+
+  const subscribers = new Map();
+
+  function notify(event, payload) {
+    const listeners = subscribers.get(event);
+    if (!listeners || listeners.size === 0) {
+      return;
+    }
+
+    listeners.forEach((listener) => {
+      try {
+        listener(payload);
+      } catch (error) {
+        console.error(`[state] Listener falhou para evento "${event}".`, error);
+      }
+    });
+  }
+
+  function persistState(keys) {
+    const keysToPersist = Array.from(keys).filter((key) => PERSISTED_KEYS.has(key));
+    if (keysToPersist.length === 0) {
+      return;
+    }
+
+    const snapshot = keysToPersist.reduce((acc, key) => {
+      acc[key] = internalState[key];
+      return acc;
+    }, {});
+
+    try {
+      const stored = global.sessionStorage?.getItem(STORAGE_KEY);
+      const existing = safeParse(stored);
+      const merged = { ...existing, ...snapshot };
+      global.sessionStorage?.setItem(STORAGE_KEY, JSON.stringify(merged));
+    } catch (error) {
+      console.warn('[state] Não foi possível salvar o estado.', error);
+    }
+  }
+
+  function clone(value) {
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(clone);
+    }
+
+    return { ...value };
+  }
+
+  function getState(key) {
+    if (!key) {
+      return clone(internalState);
+    }
+
+    return clone(internalState[key]);
+  }
+
+  function setState(updates = {}, options = {}) {
+    if (!updates || typeof updates !== 'object') {
+      return internalState;
+    }
+
+    const changedKeys = new Set();
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (!(key in internalState)) {
+        return;
+      }
+
+      const nextValue = value === undefined ? null : value;
+      const currentValue = internalState[key];
+      const isSame =
+        typeof nextValue === 'object'
+          ? JSON.stringify(nextValue) === JSON.stringify(currentValue)
+          : nextValue === currentValue;
+
+      if (isSame) {
+        return;
+      }
+
+      internalState[key] = nextValue;
+      changedKeys.add(key);
+    });
+
+    if (changedKeys.size === 0) {
+      return internalState;
+    }
+
+    persistState(changedKeys);
+
+    if (options.silent) {
+      return internalState;
+    }
+
+    notify('change', { state: getState(), changed: Array.from(changedKeys) });
+    changedKeys.forEach((key) => {
+      notify(`change:${key}`, {
+        key,
+        value: getState(key),
+      });
+    });
+
+    return internalState;
+  }
+
+  function subscribe(event, callback) {
+    if (!event || typeof callback !== 'function') {
+      return () => {};
+    }
+
+    if (!subscribers.has(event)) {
+      subscribers.set(event, new Set());
+    }
+
+    const listeners = subscribers.get(event);
+    listeners.add(callback);
+
+    return function unsubscribe() {
+      listeners.delete(callback);
+      if (listeners.size === 0) {
+        subscribers.delete(event);
+      }
+    };
+  }
+
+  const store = Object.freeze({
+    getState,
+    setState,
+    subscribe,
+    notify,
+    defaultState,
+  });
+
+  if (!global.AppState) {
+    global.AppState = store;
+  } else {
+    console.warn('[state] AppState já estava definido. Mantendo instância existente.');
+  }
+})(window);

--- a/scripts/feedback.js
+++ b/scripts/feedback.js
@@ -51,6 +51,46 @@
 
   window.showToast = showToast;
 
+  function extractErrorMessage(error, fallback = 'Ocorreu um erro inesperado.') {
+    if (!error) {
+      return fallback;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      if (typeof error.message === 'string' && error.message.trim()) {
+        return error.message;
+      }
+
+      if (typeof error.error === 'string' && error.error.trim()) {
+        return error.error;
+      }
+
+      if (typeof error.data?.message === 'string' && error.data.message.trim()) {
+        return error.data.message;
+      }
+
+      if (typeof error.data?.error === 'string' && error.data.error.trim()) {
+        return error.data.error;
+      }
+    }
+
+    return fallback;
+  }
+
+  function showError(error, options = {}) {
+    const message = extractErrorMessage(error, options.fallbackMessage);
+    showToast(message, { type: 'error', duration: options.duration ?? 6000 });
+    if (options.log !== false) {
+      console.error('[feedback] Erro apresentado ao usuário:', error);
+    }
+  }
+
+  window.showError = showError;
+
   const inlineFeedbackTimeouts = new WeakMap();
   const INLINE_FEEDBACK_SELECTOR = '[data-role="inline-feedback"]';
 

--- a/scripts/form-guards.js
+++ b/scripts/form-guards.js
@@ -1,30 +1,14 @@
 'use strict';
 
+// TODO: Criar regra ESLint que proíba window.location, modal.hide(), replaceChildren em
+// contêineres raiz (#app, .workspace, .modal-overlay) e uso indiscriminado de innerHTML.
+
 (function preventFormReloads() {
   const ATTRIBUTE_NAME = 'data-prevent-reload';
-  const ALLOW_SUBMIT_ATTRIBUTE = 'data-allow-submit';
   const formsWithGuard = new WeakSet();
-
-  function allowsNativeSubmit(form) {
-    if (!form.hasAttribute(ALLOW_SUBMIT_ATTRIBUTE)) {
-      return false;
-    }
-
-    const rawValue = form.getAttribute(ALLOW_SUBMIT_ATTRIBUTE);
-    if (rawValue === null) {
-      return true;
-    }
-
-    const normalized = rawValue.trim().toLowerCase();
-    return normalized === '' || normalized === 'true' || normalized === '1';
-  }
 
   function shouldGuard(form) {
     if (!(form instanceof HTMLFormElement)) {
-      return false;
-    }
-
-    if (allowsNativeSubmit(form)) {
       return false;
     }
 
@@ -122,11 +106,112 @@
     observer.observe(document.documentElement, { childList: true, subtree: true });
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-      scan();
-    });
-  } else {
+  function initializeGuards() {
     scan();
   }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeGuards);
+  } else {
+    initializeGuards();
+  }
 })();
+
+(function setupClickInterception() {
+  function handleClick(event) {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const anchor = target.closest('a[href="#"]');
+    if (anchor) {
+      event.preventDefault();
+      event.stopPropagation();
+      console.warn('[guards] Clique em âncora de hash vazio bloqueado.', anchor);
+      if (typeof window.showToast === 'function') {
+        window.showToast('Ação indisponível no momento.', { type: 'info', duration: 2500 });
+      }
+      return;
+    }
+
+    const actionable = target.closest('[data-action]');
+    if (!actionable) {
+      return;
+    }
+
+    const actionName = actionable.getAttribute('data-action');
+    if (typeof actionName !== 'string' || !actionName.trim() || actionName.trim() === '#') {
+      event.preventDefault();
+      console.warn('[guards] data-action genérico interceptado.', actionable);
+      if (typeof window.showToast === 'function') {
+        window.showToast('Ação não configurada.', { type: 'warning', duration: 2500 });
+      }
+    }
+  }
+
+  document.addEventListener('click', handleClick, { passive: false });
+})();
+
+(function strictNavigationGuard(global) {
+  const flag = String(global.SPA_STRICT ?? '').toLowerCase();
+  const isStrict = flag === 'true' || flag === '1';
+  if (!isStrict) {
+    return;
+  }
+
+  function logBlocked(action, details) {
+    const stack = new Error(`[SPA] Bloqueado: ${action}`).stack;
+    console.warn(`[guards] Navegação bloqueada (${action}).`, details);
+    if (stack) {
+      console.warn(stack);
+    }
+    if (typeof global.showToast === 'function') {
+      global.showToast('Navegação bloqueada no modo SPA estrito.', {
+        type: 'warning',
+        duration: 4000,
+      });
+    }
+  }
+
+  try {
+    if (global.location) {
+      const originalReload = global.location.reload?.bind(global.location);
+      if (originalReload) {
+        Object.defineProperty(global.location, 'reload', {
+          value: function blockedReload(...args) {
+            logBlocked('location.reload', args);
+            return undefined;
+          },
+          configurable: true,
+          writable: false,
+        });
+      }
+
+      const locationPrototype = global.Location?.prototype;
+      const hrefDescriptor = locationPrototype
+        ? Object.getOwnPropertyDescriptor(locationPrototype, 'href')
+        : null;
+
+      if (hrefDescriptor && typeof hrefDescriptor.set === 'function') {
+        Object.defineProperty(locationPrototype, 'href', {
+          ...hrefDescriptor,
+          set(value) {
+            logBlocked('location.href', value);
+          },
+        });
+      }
+    }
+  } catch (error) {
+    console.warn('[guards] Falha ao reforçar restrições de location.', error);
+  }
+
+  if (global.history && typeof global.history.go === 'function') {
+    const originalGo = global.history.go.bind(global.history);
+    global.history.go = function blockedHistoryGo(...args) {
+      logBlocked('history.go', args);
+      return undefined;
+    };
+    global.history.go.original = originalGo;
+  }
+})(window);


### PR DESCRIPTION
## Summary
- add SPA-aware state, router, and network utilities under scripts/core with session persistence and loading events
- harden global form guards with delegated click interception and strict navigation patches for SPA_STRICT
- standardize feedback helpers by introducing showError and wire new core scripts into index.html

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6767d563c8333be49579c7ee112b0